### PR TITLE
Added endpoint link to response json.

### DIFF
--- a/link_resolver.go
+++ b/link_resolver.go
@@ -19,6 +19,7 @@ type LinkResolverResponse struct {
 	Message string `json:"message,omitempty"`
 
 	Tooltip string `json:"tooltip,omitempty"`
+	Link string `json:"link,omitempty"`
 
 	// Flag in the BTTV API to.. maybe signify that the link will download something? idk
 	// Download *bool  `json:"download,omitempty"`
@@ -133,6 +134,7 @@ func linkResolver(w http.ResponseWriter, r *http.Request) {
 			return json.Marshal(&LinkResolverResponse{
 				Status:  resp.StatusCode,
 				Tooltip: fmt.Sprintf("<div style=\"text-align: left;\">%s<b>URL:</b> %s</div>", title, resp.Request.URL.String()),
+				Link: resp.Request.URL.String(),
 			})
 		}
 


### PR DESCRIPTION
This PR simply adds an additional field of URL to response JSON.
Made to ensure that the client does not have to parse link from tooltip text.