### PR TITLE
Specify user agent on HTTP requests

### DIFF
--- a/link_resolver.go
+++ b/link_resolver.go
@@ -41,6 +41,7 @@ func doRequest(url string) (interface{}, error) {
 	// ensures websites return pages in english (e.g. twitter would return french preview
 	// when the request came from a french IP.)
 	req.Header.Add("Accept-Language", "en-US, en;q=0.9, *;q=0.5")
+	req.Header.Set("User-Agent", "chatterino-api-cache/1.0 link-resolver")
 
 	resp, err := httpClient.Do(req)
 	if err != nil {

--- a/twitchemotes.go
+++ b/twitchemotes.go
@@ -19,6 +19,7 @@ func getData(url, key string) ([]byte, error) {
 	// ensures websites return pages in english (e.g. twitter would return french preview
 	// when the request came from a french IP.)
 	req.Header.Add("Accept-Language", "en-US, en;q=0.9, *;q=0.5")
+	req.Header.Set("User-Agent", "chatterino-api-cache/1.0 emote-sets-resolver")
 
 	resp, err := httpClient.Do(req)
 	log.Printf("Fetching %s live...", url)


### PR DESCRIPTION
Using the format specified here:

https://developer.mozilla.org/de/docs/Web/HTTP/Headers/User-Agent

It was `Go-http-client/2.0` previously which is not very useful to service operators reading logs.