### PR TITLE
Change run flags

### DIFF
--- a/link_resolver.go
+++ b/link_resolver.go
@@ -144,11 +144,15 @@ func doRequest(urlString string, r *http.Request) (interface{}, error, time.Dura
 	}
 
 	if isSupportedThumbnail(resp.Header.Get("content-type")) {
-		scheme := "https://"
-		if r.TLS == nil {
-			scheme = "http://" // https://github.com/golang/go/issues/28940#issuecomment-441749380
+		if *baseURL == "" {
+			scheme := "https://"
+			if r.TLS == nil {
+				scheme = "http://" // https://github.com/golang/go/issues/28940#issuecomment-441749380
+			}
+			response.Thumbnail = fmt.Sprintf("%s%s/thumbnail/%s", scheme, r.Host, url.QueryEscape(resp.Request.URL.String()))
+		} else {
+			response.Thumbnail = fmt.Sprintf("%s/thumbnail/%s", strings.TrimSuffix(*baseURL, "/"), url.QueryEscape(resp.Request.URL.String()))
 		}
-		response.Thumbnail = fmt.Sprintf("%s%s/%sthumbnail/%s", scheme, r.Host, strings.TrimPrefix(*prefix, "/"), url.QueryEscape(resp.Request.URL.String()))
 	}
 
 	return marshalNoDur(response)

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ var (
 )
 
 var bind = flag.String("l", ":1234", "bind address")
-var baseURL = flag.String("b", "", "base url (useful if being proxied through nginx or some shit). value needs to be full url up to the application (e.g. https://braize.pajlada.com/chatterino/)")
+var baseURL = flag.String("b", "", "base url (useful if being proxied through nginx or some shit). value needs to be full url up to the application (e.g. https://braize.pajlada.com/chatterino)")
 
 var prefix string
 


### PR DESCRIPTION
Changed host flag -h to bind address -l
Removed prefix flag -p, replaced it with similar baseURL -b

Example usage from braize:
./api -l 127.0.0.1:1234 -b https://braize.pajlada.com/chatterino