### PR TITLE
Added Publish Date for YouTube videos

### DIFF
--- a/link_resolver_youtube.go
+++ b/link_resolver_youtube.go
@@ -23,6 +23,7 @@ const youtubeTooltip = `<div style="text-align: left;">
 <b>{{.Title}}</b>
 <br><b>Channel:</b> {{.ChannelTitle}}
 <br><b>Duration:</b> {{.Duration}}
+<br><b>Published:</b> {{.PublishDate}}
 <br><b>Views:</b> {{.Views}}
 <br><span style="color: #2ecc71;">{{.LikeCount}} likes</span>&nbsp;•&nbsp;<span style="color: #e74c3c;">{{.DislikeCount}} dislikes</span>
 </div>
@@ -32,6 +33,7 @@ type youtubeTooltipData struct {
 	Title        string
 	ChannelTitle string
 	Duration     string
+	PublishDate  string
 	Views        string
 	LikeCount    string
 	DislikeCount string
@@ -93,6 +95,7 @@ func init() {
 			Title:        video.Snippet.Title,
 			ChannelTitle: video.Snippet.ChannelTitle,
 			Duration:     formatDuration(video.ContentDetails.Duration),
+			PublishDate:  formatDate("02 Jan 2006", video.Snippet.PublishedAt),
 			Views:        insertCommas(strconv.FormatUint(video.Statistics.ViewCount, 10), 3),
 			LikeCount:    insertCommas(strconv.FormatUint(video.Statistics.LikeCount, 10), 3),
 			DislikeCount: insertCommas(strconv.FormatUint(video.Statistics.DislikeCount, 10), 3),

--- a/utils.go
+++ b/utils.go
@@ -48,6 +48,15 @@ func insertCommas(str string, n int) string {
 	return buffer.String()
 }
 
+func formatDate(format string, str string) string {
+	date, err := time.Parse(time.RFC3339, str)
+	if err != nil {
+		return ""
+	} else {
+		return date.Format(format)
+	}
+}
+
 func marshalNoDur(i interface{}) ([]byte, error, time.Duration) {
 	data, err := json.Marshal(i)
 	return data, err, noSpecialDur


### PR DESCRIPTION
Closes #19 

Date is in format `02 Jan 2006`. I think it is better than `2006-01-02` because it doesn't confuse Americans KKona

![](https://cdn.zneix.eu/x0PTeUm.png)

I decided that comment count is not needed, but I can add it in this PR if someone thinks it's a good idea. It might be right next to dislike count 