### PR TITLE
Rich Twitter Tooltips

### DIFF
--- a/link_resolver_twitter.go
+++ b/link_resolver_twitter.go
@@ -316,7 +316,9 @@ func init() {
 			}
 
 			if twitterUserRegexp.MatchString(url.String()) {
-				userName := getUserNameFromUrl(url)
+				// We always use the lowercase representation in order
+				// to avoid making redundant requests.
+				userName := strings.ToLower(getUserNameFromUrl(url))
 				if userName == "" {
 					return rNoLinkInfoFound, nil
 				}

--- a/link_resolver_twitter.go
+++ b/link_resolver_twitter.go
@@ -25,7 +25,7 @@ const (
 <br>
 {{.Text}}
 <br>
-<span style="color: #808892;">{{.Timestamp}}</span>
+<span style="color: #808892;">{{.Likes}} likes&nbsp;•&nbsp;{{.Retweets}} retweets&nbsp;•&nbsp;{{.Timestamp}}</span>
 </div>
 `
 
@@ -48,6 +48,8 @@ type TweetApiResponse struct {
 	ID        string `json:"id_str"`
 	Text      string `json:"full_text"`
 	Timestamp string `json:"created_at"`
+	Likes     uint64 `json:"favorite_count"`
+	Retweets  uint64 `json:"retweet_count"`
 	User      struct {
 		Name            string `json:"name"`
 		Username        string `json:"screen_name"`
@@ -65,6 +67,8 @@ type tweetTooltipData struct {
 	Name      string
 	Username  string
 	Timestamp string
+	Likes     string
+	Retweets  string
 	Thumbnail string
 }
 
@@ -124,6 +128,8 @@ func buildTweetTooltip(tweet *TweetApiResponse) *tweetTooltipData {
 	data.Text = tweet.Text
 	data.Name = tweet.User.Name
 	data.Username = tweet.User.Username
+	data.Likes = insertCommas(strconv.FormatUint(tweet.Likes, 10), 3)
+	data.Retweets = insertCommas(strconv.FormatUint(tweet.Retweets, 10), 3)
 
 	timestamp, err := time.Parse("Mon Jan 2 15:04:05 -0700 2006", tweet.Timestamp)
 	data.Timestamp = timestamp.Format(timestampFormat)

--- a/link_resolver_twitter.go
+++ b/link_resolver_twitter.go
@@ -147,7 +147,9 @@ func init() {
 
 	customURLManagers = append(customURLManagers, customURLManager{
 		check: func(url *url.URL) bool {
-			return strings.HasSuffix(url.Host, ".twitter.com") || url.Host == "twitter.com"
+			// Additionally checking the regex to provide default link resolver response on non-status links
+			return (strings.HasSuffix(url.Host, ".twitter.com") || url.Host == "twitter.com") &&
+				tweetRegexp.MatchString(url.String())
 		},
 		run: func(url *url.URL) ([]byte, error) {
 			tweetID := getTweetIDFromURL(url)

--- a/link_resolver_twitter.go
+++ b/link_resolver_twitter.go
@@ -1,19 +1,19 @@
 package main
 
 import (
-    "bytes"
-    "encoding/json"
-    "errors"
-    "fmt"
-    "net/http"
-    "os"
-    "time"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
 
-    "log"
-    "net/url"
-    "regexp"
-    "strings"
-    "text/template"
+	"log"
+	"net/url"
+	"regexp"
+	"strings"
+	"text/template"
 )
 
 const tweeterTooltip = `<div style="text-align: left;">
@@ -24,135 +24,139 @@ const tweeterTooltip = `<div style="text-align: left;">
 `
 
 var (
-    tweetRegexp = regexp.MustCompile(`(?i)\/.*\/status(?:es)?\/([^\/\?]+)`)
+	tweetRegexp = regexp.MustCompile(`(?i)\/.*\/status(?:es)?\/([^\/\?]+)`)
 )
 
 type TweetApiResponse struct {
-    ID       string `json:"id_str"`
-    Text     string `json:"full_text"`
-    Entities struct {
-        Media []struct {
-            URL string `json:"media_url_https"`
-        } `json:"media"`
-    } `json:"entities"`
-    User struct {
-        Name     string `json:"name"`
-        Username string `json:"screen_name"`
-    } `json:"user"`
+	ID       string `json:"id_str"`
+	Text     string `json:"full_text"`
+	Entities struct {
+		Media []struct {
+			URL string `json:"media_url_https"`
+		} `json:"media"`
+	} `json:"entities"`
+	User struct {
+		Name     string `json:"name"`
+		Username string `json:"screen_name"`
+	} `json:"user"`
 }
 
 type tweetTooltipData struct {
-    Text      string
-    Name      string
-    Username  string
-    Thumbnail string
+	Text      string
+	Name      string
+	Username  string
+	Thumbnail string
 }
 
 func getTweetIDFromURL(url *url.URL) string {
-    match := tweetRegexp.FindAllStringSubmatch(url.Path, -1)
-    if len(match) > 0 && len(match[0]) == 2 {
-        return match[0][1]
-    }
-    return ""
+	match := tweetRegexp.FindAllStringSubmatch(url.Path, -1)
+	if len(match) > 0 && len(match[0]) == 2 {
+		return match[0][1]
+	}
+	return ""
 }
 
 func getTweetByID(id, bearer string) (*TweetApiResponse, error) {
-    endpointUrl := fmt.Sprintf("https://api.twitter.com/1.1/statuses/show.json?id=%s&tweet_mode=extended", id)
-    req, err := http.NewRequest("GET", endpointUrl, nil)
-    if err != nil {
-        return nil, err
-    }
-    req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", bearer))
-    resp, err := httpClient.Do(req)
-    if err != nil {
-        return nil, err
-    }
+	endpointUrl := fmt.Sprintf("https://api.twitter.com/1.1/statuses/show.json?id=%s&tweet_mode=extended", id)
+	req, err := http.NewRequest("GET", endpointUrl, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", bearer))
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
 
-    defer resp.Body.Close()
+	defer resp.Body.Close()
 
-    if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-        return nil, fmt.Errorf("%d", resp.StatusCode)
-    }
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("%d", resp.StatusCode)
+	}
 
-    var tweet *TweetApiResponse
-    err = json.NewDecoder(resp.Body).Decode(&tweet)
-    if err != nil {
-        return nil, errors.New("unable to process response")
-    }
+	var tweet *TweetApiResponse
+	err = json.NewDecoder(resp.Body).Decode(&tweet)
+	if err != nil {
+		return nil, errors.New("unable to process response")
+	}
 
-    return tweet, nil
+	return tweet, nil
 }
 
 func buildTooltip(tweet *TweetApiResponse) *tweetTooltipData {
-    data := &tweetTooltipData{}
-    data.Text = tweet.Text
-    data.Name = tweet.User.Name
-    data.Username = tweet.User.Username
+	data := &tweetTooltipData{}
+	data.Text = tweet.Text
+	data.Name = tweet.User.Name
+	data.Username = tweet.User.Username
 
-    if len(tweet.Entities.Media) > 0 {
-        data.Thumbnail = tweet.Entities.Media[0].URL
-    }
+	if len(tweet.Entities.Media) > 0 {
+		data.Thumbnail = tweet.Entities.Media[0].URL
+	}
 
-    return data
+	return data
 }
 
 func init() {
-    bearerKey, exists := os.LookupEnv("CHATTERINO_API_TWITTER_BEARER_TOKEN")
-    if !exists {
-       log.Println("No CHATTERINO_API_TWITTER_BEARER_TOKEN specified, won't do special responses for twitter")
-       return
-    }
+	bearerKey, exists := os.LookupEnv("CHATTERINO_API_TWITTER_BEARER_TOKEN")
+	if !exists {
+		log.Println("No CHATTERINO_API_TWITTER_BEARER_TOKEN specified, won't do special responses for twitter")
+		return
+	}
 
-    tooltipTemplate, err := template.New("tweetTooltip").Parse(tweeterTooltip)
-    if err != nil {
-        log.Println("Error initializing Tweet tooltip template:", err)
-        return
-    }
+	tooltipTemplate, err := template.New("tweetTooltip").Parse(tweeterTooltip)
+	if err != nil {
+		log.Println("Error initializing Tweet tooltip template:", err)
+		return
+	}
 
-    load := func(tweetID string, r *http.Request) (interface{}, error, time.Duration) {
-        log.Println("[Twitter] GET", tweetID)
+	load := func(tweetID string, r *http.Request) (interface{}, error, time.Duration) {
+		log.Println("[Twitter] GET", tweetID)
 
-        tweetResp, err := getTweetByID(tweetID, bearerKey)
-        if err != nil {
-            if err.Error() == "404" {
-                var response LinkResolverResponse
-                json.Unmarshal(rNoLinkInfoFound, &response)
+		tweetResp, err := getTweetByID(tweetID, bearerKey)
+		if err != nil {
+			if err.Error() == "404" {
+				var response LinkResolverResponse
+				json.Unmarshal(rNoLinkInfoFound, &response)
 
-                return &response, nil, 1 * time.Hour
-            }
-        }
+				return &response, nil, 1 * time.Hour
+			}
 
-        tweetData := buildTooltip(tweetResp)
-        var tooltip bytes.Buffer
-        if err := tooltipTemplate.Execute(&tooltip, tweetData); err != nil {
-            return &LinkResolverResponse{
-                Status:  http.StatusInternalServerError,
-                Message: "twitter template error " + clean(err.Error()),
-            }, nil, noSpecialDur
-        }
+			return &LinkResolverResponse{
+				Status:  http.StatusInternalServerError,
+                Message: "Error getting Tweet: " + clean(err.Error()),
+			}, nil, noSpecialDur
+		}
 
-        return &LinkResolverResponse{
-            Status:    http.StatusOK,
-            Tooltip:   tooltip.String(),
-            Thumbnail: tweetData.Thumbnail,
-        }, nil, noSpecialDur
-    }
+		tweetData := buildTooltip(tweetResp)
+		var tooltip bytes.Buffer
+		if err := tooltipTemplate.Execute(&tooltip, tweetData); err != nil {
+			return &LinkResolverResponse{
+				Status:  http.StatusInternalServerError,
+                Message: "Tweet template error: " + clean(err.Error()),
+			}, nil, noSpecialDur
+		}
 
-    cache := newLoadingCache("twitter", load, 24*time.Hour)
+		return &LinkResolverResponse{
+			Status:    http.StatusOK,
+			Tooltip:   tooltip.String(),
+			Thumbnail: tweetData.Thumbnail,
+		}, nil, noSpecialDur
+	}
 
-    customURLManagers = append(customURLManagers, customURLManager{
-        check: func(url *url.URL) bool {
-            return strings.HasSuffix(url.Host, ".twitter.com") || url.Host == "twitter.com"
-        },
-        run: func(url *url.URL) ([]byte, error) {
-            tweetID := getTweetIDFromURL(url)
-            if tweetID == "" {
-                return rNoLinkInfoFound, nil
-            }
+	cache := newLoadingCache("twitter", load, 24*time.Hour)
 
-            apiResponse := cache.Get(tweetID, nil)
-            return json.Marshal(apiResponse)
-        },
-    })
+	customURLManagers = append(customURLManagers, customURLManager{
+		check: func(url *url.URL) bool {
+			return strings.HasSuffix(url.Host, ".twitter.com") || url.Host == "twitter.com"
+		},
+		run: func(url *url.URL) ([]byte, error) {
+			tweetID := getTweetIDFromURL(url)
+			if tweetID == "" {
+				return rNoLinkInfoFound, nil
+			}
+
+			apiResponse := cache.Get(tweetID, nil)
+			return json.Marshal(apiResponse)
+		},
+	})
 }
-

--- a/link_resolver_twitter.go
+++ b/link_resolver_twitter.go
@@ -66,10 +66,12 @@ func init() {
 
         tweetResp, err := getTweetByID(tweetID, bearerKey)
         if err != nil {
-            return &LinkResolverResponse{
-                Status:  http.StatusInternalServerError,
-                Message: "twitter error: " + clean(err.Error()),
-            }, nil, 1 * time.Hour
+            if err.Error() == "404" {
+                var response LinkResolverResponse
+                json.Unmarshal(rNoLinkInfoFound, &response)
+
+                return &response, nil, 1 * time.Hour
+            }
         }
 
         tweetData := tweet2Tooltip(tweetResp)
@@ -129,7 +131,7 @@ func getTweetByID(id, bearer string) (*TweetApiResponse, error) {
     defer resp.Body.Close()
 
     if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-        return nil, fmt.Errorf("responded with status %d", resp.StatusCode)
+        return nil, fmt.Errorf("%d", resp.StatusCode)
     }
 
     var tweet *TweetApiResponse

--- a/link_resolver_twitter.go
+++ b/link_resolver_twitter.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -19,7 +20,7 @@ import (
 const (
 	timestampFormat = "Jan 2 2006 • 15:04 UTC"
 
-	tweeterTooltip = `<div style="text-align: left;">
+	tweetTooltip = `<div style="text-align: left;">
 <b>{{.Name}} (@{{.Username}})</b>
 <br>
 {{.Text}}
@@ -27,10 +28,20 @@ const (
 <span style="color: #808892;">{{.Timestamp}}</span>
 </div>
 `
+
+	twitterUserTooltip = `<div style="text-align: left;">
+<b>{{.Name}} (@{{.Username}})</b>
+<br>
+{{.Description}}
+<br>
+<span style="color: #808892;">{{.Followers}} followers</span>
+</div>
+`
 )
 
 var (
-	tweetRegexp = regexp.MustCompile(`(?i)\/.*\/status(?:es)?\/([^\/\?]+)`)
+	tweetRegexp       = regexp.MustCompile(`(?i)\/.*\/status(?:es)?\/([^\/\?]+)`)
+	twitterUserRegexp = regexp.MustCompile(`(?i)twitter\.com\/([^\/\?\s]+)(\/?$|(\?).*)`)
 )
 
 type TweetApiResponse struct {
@@ -38,12 +49,13 @@ type TweetApiResponse struct {
 	Text      string `json:"full_text"`
 	Timestamp string `json:"created_at"`
 	User      struct {
-		Name     string `json:"name"`
-		Username string `json:"screen_name"`
+		Name            string `json:"name"`
+		Username        string `json:"screen_name"`
+		ProfileImageUrl string `json:"profile_image_url_https"`
 	} `json:"user"`
 	Entities struct {
 		Media []struct {
-			URL string `json:"media_url_https"`
+			Url string `json:"media_url_https"`
 		} `json:"media"`
 	} `json:"entities"`
 }
@@ -54,6 +66,22 @@ type tweetTooltipData struct {
 	Username  string
 	Timestamp string
 	Thumbnail string
+}
+
+type TwitterUserApiResponse struct {
+	Name            string `json:"name"`
+	Username        string `json:"screen_name"`
+	Description     string `json:"description"`
+	Followers       uint64 `json:"followers_count"`
+	ProfileImageUrl string `json:"profile_image_url_https"`
+}
+
+type twitterUserTooltipData struct {
+	Name        string
+	Username    string
+	Description string
+	Followers   string
+	Thumbnail   string
 }
 
 func getTweetIDFromURL(url *url.URL) string {
@@ -91,7 +119,7 @@ func getTweetByID(id, bearer string) (*TweetApiResponse, error) {
 	return tweet, nil
 }
 
-func buildTooltip(tweet *TweetApiResponse) *tweetTooltipData {
+func buildTweetTooltip(tweet *TweetApiResponse) *tweetTooltipData {
 	data := &tweetTooltipData{}
 	data.Text = tweet.Text
 	data.Name = tweet.User.Name
@@ -105,8 +133,55 @@ func buildTooltip(tweet *TweetApiResponse) *tweetTooltipData {
 	}
 
 	if len(tweet.Entities.Media) > 0 {
-		data.Thumbnail = tweet.Entities.Media[0].URL
+		// If tweet contains an image, it will be used as thumbnail
+		data.Thumbnail = tweet.Entities.Media[0].Url
 	}
+
+	return data
+}
+
+func getUserNameFromUrl(url *url.URL) string {
+	match := twitterUserRegexp.FindAllStringSubmatch(url.String(), -1)
+	if len(match) > 0 && len(match[0]) > 0 {
+		return match[0][1]
+	}
+	return ""
+}
+
+func getUserByName(userName, bearer string) (*TwitterUserApiResponse, error) {
+	endpointUrl := fmt.Sprintf("https://api.twitter.com/1.1/users/show.json?screen_name=%s", userName)
+	req, err := http.NewRequest("GET", endpointUrl, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", bearer))
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("%d", resp.StatusCode)
+	}
+
+	var user *TwitterUserApiResponse
+	err = json.NewDecoder(resp.Body).Decode(&user)
+	if err != nil {
+		return nil, errors.New("unable to process response")
+	}
+
+	return user, nil
+}
+
+func buildTwitterUserTooltip(user *TwitterUserApiResponse) *twitterUserTooltipData {
+	data := &twitterUserTooltipData{}
+	data.Name = user.Name
+	data.Username = user.Username
+	data.Description = user.Description
+	data.Followers = insertCommas(strconv.FormatUint(user.Followers, 10), 3)
+	data.Thumbnail = user.ProfileImageUrl
 
 	return data
 }
@@ -118,13 +193,19 @@ func init() {
 		return
 	}
 
-	tooltipTemplate, err := template.New("tweetTooltip").Parse(tweeterTooltip)
+	tweetTooltipTemplate, err := template.New("tweetTooltip").Parse(tweetTooltip)
 	if err != nil {
 		log.Println("Error initializing Tweet tooltip template:", err)
 		return
 	}
 
-	load := func(tweetID string, r *http.Request) (interface{}, error, time.Duration) {
+	twitterUserTooltipTemplate, err := template.New("twitterUserTooltip").Parse(twitterUserTooltip)
+	if err != nil {
+		log.Println("Error initializing Tweet tooltip template:", err)
+		return
+	}
+
+	loadTweet := func(tweetID string, r *http.Request) (interface{}, error, time.Duration) {
 		log.Println("[Twitter] GET", tweetID)
 
 		tweetResp, err := getTweetByID(tweetID, bearerKey)
@@ -145,9 +226,9 @@ func init() {
 			}, nil, noSpecialDur
 		}
 
-		tweetData := buildTooltip(tweetResp)
+		tweetData := buildTweetTooltip(tweetResp)
 		var tooltip bytes.Buffer
-		if err := tooltipTemplate.Execute(&tooltip, tweetData); err != nil {
+		if err := tweetTooltipTemplate.Execute(&tooltip, tweetData); err != nil {
 			return &LinkResolverResponse{
 				Status:  http.StatusInternalServerError,
 				Message: "Tweet template error: " + clean(err.Error()),
@@ -161,22 +242,84 @@ func init() {
 		}, nil, noSpecialDur
 	}
 
-	cache := newLoadingCache("twitter", load, 24*time.Hour)
+	loadTwitterUser := func(userName string, r *http.Request) (interface{}, error, time.Duration) {
+		log.Println("[Twitter] GET", userName)
+
+		userResp, err := getUserByName(userName, bearerKey)
+		if err != nil {
+			if err.Error() == "50" {
+				var response LinkResolverResponse
+				unmarshalErr := json.Unmarshal(rNoLinkInfoFound, &response)
+				if unmarshalErr != nil {
+					log.Println("Error unmarshalling prebuilt response:", unmarshalErr.Error())
+				}
+
+				return &response, nil, 1 * time.Hour
+			}
+
+			return &LinkResolverResponse{
+				Status:  http.StatusInternalServerError,
+				Message: "Error getting Twitter user: " + clean(err.Error()),
+			}, nil, noSpecialDur
+		}
+
+		userData := buildTwitterUserTooltip(userResp)
+		var tooltip bytes.Buffer
+		if err := twitterUserTooltipTemplate.Execute(&tooltip, userData); err != nil {
+			return &LinkResolverResponse{
+				Status:  http.StatusInternalServerError,
+				Message: "Twitter user template error: " + clean(err.Error()),
+			}, nil, noSpecialDur
+		}
+
+		return &LinkResolverResponse{
+			Status:    http.StatusOK,
+			Tooltip:   tooltip.String(),
+			Thumbnail: userData.Thumbnail,
+		}, nil, noSpecialDur
+	}
+
+	tweetCache := newLoadingCache("tweets", loadTweet, 24*time.Hour)
+	twitterUserCache := newLoadingCache("twitterUsers", loadTwitterUser, 24*time.Hour)
 
 	customURLManagers = append(customURLManagers, customURLManager{
 		check: func(url *url.URL) bool {
-			// Additionally checking the regex to provide default link resolver response on non-status links
-			return (strings.HasSuffix(url.Host, ".twitter.com") || url.Host == "twitter.com") &&
-				tweetRegexp.MatchString(url.String())
-		},
-		run: func(url *url.URL) ([]byte, error) {
-			tweetID := getTweetIDFromURL(url)
-			if tweetID == "" {
-				return rNoLinkInfoFound, nil
+			isTwitter := (strings.HasSuffix(url.Host, ".twitter.com") || url.Host == "twitter.com")
+
+			if !isTwitter {
+				return false
 			}
 
-			apiResponse := cache.Get(tweetID, nil)
-			return json.Marshal(apiResponse)
+			isTweet := tweetRegexp.MatchString(url.String())
+			if isTweet {
+				return true
+			}
+
+			isTwitterUser := twitterUserRegexp.MatchString(url.String())
+			return isTwitterUser
+		},
+		run: func(url *url.URL) ([]byte, error) {
+			if tweetRegexp.MatchString(url.String()) {
+				tweetID := getTweetIDFromURL(url)
+				if tweetID == "" {
+					return rNoLinkInfoFound, nil
+				}
+
+				apiResponse := tweetCache.Get(tweetID, nil)
+				return json.Marshal(apiResponse)
+			}
+
+			if twitterUserRegexp.MatchString(url.String()) {
+				userName := getUserNameFromUrl(url)
+				if userName == "" {
+					return rNoLinkInfoFound, nil
+				}
+
+				apiResponse := twitterUserCache.Get(userName, nil)
+				return json.Marshal(apiResponse)
+			}
+
+			return rNoLinkInfoFound, nil
 		},
 	})
 }

--- a/link_resolver_twitter.go
+++ b/link_resolver_twitter.go
@@ -105,7 +105,7 @@ func init() {
 
     tooltipTemplate, err := template.New("tweetTooltip").Parse(tweeterTooltip)
     if err != nil {
-        log.Println("Error initialization tweeter tooltip template:", err)
+        log.Println("Error initializing Tweet tooltip template:", err)
         return
     }
 

--- a/link_resolver_twitter.go
+++ b/link_resolver_twitter.go
@@ -122,7 +122,7 @@ func init() {
             }
         }
 
-        tweetData := tweet2Tooltip(tweetResp)
+        tweetData := buildTooltip(tweetResp)
         var tooltip bytes.Buffer
         if err := tooltipTemplate.Execute(&tooltip, tweetData); err != nil {
             return &LinkResolverResponse{

--- a/link_resolver_twitter.go
+++ b/link_resolver_twitter.go
@@ -83,7 +83,7 @@ func getTweetByID(id, bearer string) (*TweetApiResponse, error) {
     return tweet, nil
 }
 
-func tweet2Tooltip(tweet *TweetApiResponse) *tweetTooltipData {
+func buildTooltip(tweet *TweetApiResponse) *tweetTooltipData {
     data := &tweetTooltipData{}
     data.Text = tweet.Text
     data.Name = tweet.User.Name

--- a/link_resolver_twitter.go
+++ b/link_resolver_twitter.go
@@ -7,12 +7,12 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"log"
 	"net/url"
 	"regexp"
-	"strings"
 	"text/template"
 )
 

--- a/link_resolver_twitter.go
+++ b/link_resolver_twitter.go
@@ -123,7 +123,7 @@ func init() {
 
 			return &LinkResolverResponse{
 				Status:  http.StatusInternalServerError,
-                Message: "Error getting Tweet: " + clean(err.Error()),
+				Message: "Error getting Tweet: " + clean(err.Error()),
 			}, nil, noSpecialDur
 		}
 
@@ -132,7 +132,7 @@ func init() {
 		if err := tooltipTemplate.Execute(&tooltip, tweetData); err != nil {
 			return &LinkResolverResponse{
 				Status:  http.StatusInternalServerError,
-                Message: "Tweet template error: " + clean(err.Error()),
+				Message: "Tweet template error: " + clean(err.Error()),
 			}, nil, noSpecialDur
 		}
 

--- a/link_resolver_twitter.go
+++ b/link_resolver_twitter.go
@@ -122,7 +122,7 @@ func getTweetByID(id, bearer string) (*TweetApiResponse, error) {
     if err != nil {
         return nil, err
     }
-    req.Header.Set("Authorization", "Bearer "+bearer)
+    req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", bearer))
     resp, err := httpClient.Do(req)
     if err != nil {
         return nil, err

--- a/link_resolver_twitter.go
+++ b/link_resolver_twitter.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+    "bytes"
+    "encoding/json"
+    "errors"
+    "fmt"
+    "net/http"
+    "os"
+    "time"
+
+    "log"
+    "net/url"
+    "regexp"
+    "strings"
+    "text/template"
+)
+
+const tweeterTooltip = `<div style="text-align: left;">
+<b>{{.Name}} (@{{.Username}})</b>
+<br>
+{{.Text}}
+</div>
+`
+
+var (
+    tweetRegexp = regexp.MustCompile(`(?i)\/.*\/status(?:es)?\/([^\/\?]+)`)
+)
+
+type TweetApiResponse struct {
+    ID       string `json:"id_str"`
+    Text     string `json:"full_text"`
+    Entities struct {
+        Media []struct {
+            URL string `json:"media_url_https"`
+        } `json:"media"`
+    } `json:"entities"`
+    User struct {
+        Name     string `json:"name"`
+        Username string `json:"screen_name"`
+    } `json:"user"`
+}
+
+type tweetTooltipData struct {
+    Text      string
+    Name      string
+    Username  string
+    Thumbnail string
+}
+
+func init() {
+    bearerKey, exists := os.LookupEnv("CHATTERINO_API_TWITTER_BEARER_TOKEN")
+    if !exists {
+       log.Println("No CHATTERINO_API_TWITTER_BEARER_TOKEN specified, won't do special responses for twitter")
+       return
+    }
+
+    tooltipTemplate, err := template.New("tweetTooltip").Parse(tweeterTooltip)
+    if err != nil {
+        log.Println("Error initialization tweeter tooltip template:", err)
+        return
+    }
+
+    load := func(tweetID string, r *http.Request) (interface{}, error, time.Duration) {
+        log.Println("[Twitter] GET", tweetID)
+
+        tweetResp, err := getTweetByID(tweetID, bearerKey)
+        if err != nil {
+            return &LinkResolverResponse{
+                Status:  http.StatusInternalServerError,
+                Message: "twitter error: " + clean(err.Error()),
+            }, nil, 1 * time.Hour
+        }
+
+        tweetData := tweet2Tooltip(tweetResp)
+        var tooltip bytes.Buffer
+        if err := tooltipTemplate.Execute(&tooltip, tweetData); err != nil {
+            return &LinkResolverResponse{
+                Status:  http.StatusInternalServerError,
+                Message: "twitter template error " + clean(err.Error()),
+            }, nil, noSpecialDur
+        }
+
+        return &LinkResolverResponse{
+            Status:    http.StatusOK,
+            Tooltip:   tooltip.String(),
+            Thumbnail: tweetData.Thumbnail,
+        }, nil, noSpecialDur
+    }
+
+    cache := newLoadingCache("twitter", load, 24*time.Hour)
+
+    customURLManagers = append(customURLManagers, customURLManager{
+        check: func(url *url.URL) bool {
+            return strings.HasSuffix(url.Host, ".twitter.com") || url.Host == "twitter.com"
+        },
+        run: func(url *url.URL) ([]byte, error) {
+            tweetID := getTweetIDFromURL(url)
+            if tweetID == "" {
+                return rNoLinkInfoFound, nil
+            }
+
+            apiResponse := cache.Get(tweetID, nil)
+            return json.Marshal(apiResponse)
+        },
+    })
+}
+
+func getTweetIDFromURL(url *url.URL) string {
+    match := tweetRegexp.FindAllStringSubmatch(url.Path, -1)
+    if len(match) > 0 && len(match[0]) == 2 {
+        return match[0][1]
+    }
+    return ""
+}
+
+func getTweetByID(id, bearer string) (*TweetApiResponse, error) {
+    endpointUrl := fmt.Sprintf("https://api.twitter.com/1.1/statuses/show.json?id=%s&tweet_mode=extended", id)
+    req, err := http.NewRequest("GET", endpointUrl, nil)
+    if err != nil {
+        return nil, err
+    }
+    req.Header.Set("Authorization", "Bearer "+bearer)
+    resp, err := httpClient.Do(req)
+    if err != nil {
+        return nil, err
+    }
+
+    defer resp.Body.Close()
+
+    if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+        return nil, fmt.Errorf("responded with status %d", resp.StatusCode)
+    }
+
+    var tweet *TweetApiResponse
+    err = json.NewDecoder(resp.Body).Decode(&tweet)
+    if err != nil {
+        return nil, errors.New("unable to process response")
+    }
+
+    return tweet, nil
+}
+
+func tweet2Tooltip(tweet *TweetApiResponse) *tweetTooltipData {
+    data := &tweetTooltipData{}
+    data.Text = tweet.Text
+    data.Name = tweet.User.Name
+    data.Username = tweet.User.Username
+
+    if len(tweet.Entities.Media) > 0 {
+        data.Thumbnail = tweet.Entities.Media[0].URL
+    }
+
+    return data
+}

--- a/link_resolver_twitter.go
+++ b/link_resolver_twitter.go
@@ -131,7 +131,10 @@ func init() {
 		if err != nil {
 			if err.Error() == "404" {
 				var response LinkResolverResponse
-				json.Unmarshal(rNoLinkInfoFound, &response)
+				unmarshalErr := json.Unmarshal(rNoLinkInfoFound, &response)
+				if unmarshalErr != nil {
+					log.Println("Error unmarshalling prebuilt response:", unmarshalErr.Error())
+				}
 
 				return &response, nil, 1 * time.Hour
 			}


### PR DESCRIPTION
## Technical
This PR adds rich tooltip data for Twitter links. The code structure heavily follows #33 but it differs where I saw fit.
Other than #33, this implementation uses the v1 Twitter API, and the [`GET statuses/show/:id`](https://developer.twitter.com/en/docs/twitter-api/v1/tweets/post-and-engage/api-reference/get-statuses-show-id) endpoint in particular.

As recommended on the [Twitter Developer Docs](https://developer.twitter.com/en/docs/authentication/oauth-2-0), an OAuth Bearer token is used to authenticate the application:
>OAuth 2.0 Bearer Token authenticates requests on behalf of your developer App. As this method is specific to the App, it does not involve any users. **This method is typically for developers that need read-only access to public information.**

The token is stored in the `CHATTERINO_API_TWITTER_BEARER_TOKEN` environment variable.

## Description
When hovering a Twitter status link, a tooltip with the Tweet's author, the text, and a timestamp is displayed. If the Tweet contains an image, it is also displayed. Closes #24.

If a Twitter profile link is hovered, a tooltip with the profile image, the user's name, the user's description, and their follower count is displayed.

For every other Twitter link, the default link resolver action will be used.

## Open Questions
- Twitter's API response already includes the `media_url_https` field for embedded media and the `profile_image_url_https` field for user profile images. Currently, these are sent as thumbnail URLs. Should we cache them ourselves and sent a link to the cached image instead?
- Tweet timestamps are currently always displayed in UTC. Does it make sense to keep this, or should the field be removed altogether?
- Tweet and User information is currently handled in the same source file. Should they be separated instead?

-------------

This is my first time doing anything non-trivial in Go, so I am happy to work through any criticism of the code. :smile: 