### PR TITLE
Made TwitchClip tooltips more descriptive

### DIFF
--- a/link_resolver.go
+++ b/link_resolver.go
@@ -110,9 +110,8 @@ func formatThumbnailUrl(r *http.Request, urlString string) string {
 			scheme = "http://" // https://github.com/golang/go/issues/28940#issuecomment-441749380
 		}
 		return fmt.Sprintf("%s%s/thumbnail/%s", scheme, r.Host, url.QueryEscape(urlString))
-	} else {
-		return fmt.Sprintf("%s/thumbnail/%s", strings.TrimSuffix(*baseURL, "/"), url.QueryEscape(urlString))
 	}
+	return fmt.Sprintf("%s/thumbnail/%s", strings.TrimSuffix(*baseURL, "/"), url.QueryEscape(urlString))
 }
 
 func doRequest(urlString string, r *http.Request) (interface{}, error, time.Duration) {

--- a/link_resolver_twitchclips.go
+++ b/link_resolver_twitchclips.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
 	"net/url"
@@ -23,12 +24,16 @@ var noTwitchClipWithThisIDFound = &LinkResolverResponse{
 const twitchClipsTooltip = `<div style="text-align: left;">
 <b>{{.Title}}</b><hr>
 <b>Channel:</b> {{.ChannelName}}<br>
+<b>Duration:</b> {{.Duration}}<br>
+<b>Created:</b> {{.CreationDate}}<br>
 <b>Views: </b> {{.Views}}</div>`
 
 type twitchClipsTooltipData struct {
-	Title       string
-	ChannelName string
-	Views       string
+	Title        string
+	ChannelName  string
+	Duration     string
+	CreationDate string
+	Views        string
 }
 
 func init() {
@@ -54,16 +59,18 @@ func init() {
 		}
 
 		data := twitchClipsTooltipData{
-			Title:       clip.Title,
-			ChannelName: clip.Broadcaster.DisplayName,
-			Views:       insertCommas(strconv.FormatInt(int64(clip.Views), 10), 3),
+			Title:        clip.Title,
+			ChannelName:  clip.Broadcaster.DisplayName,
+			Duration:     fmt.Sprintf("%g%s", clip.Duration, "s"),
+			CreationDate: clip.CreatedAt.Format("02 Jan 2006"),
+			Views:        insertCommas(strconv.FormatInt(int64(clip.Views), 10), 3),
 		}
 
 		var tooltip bytes.Buffer
 		if err := tooltipTemplate.Execute(&tooltip, data); err != nil {
 			return &LinkResolverResponse{
 				Status:  http.StatusInternalServerError,
-				Message: "youtube template error " + clean(err.Error()),
+				Message: "twitch clip template error " + clean(err.Error()),
 			}, nil, noSpecialDur
 		}
 

--- a/utils.go
+++ b/utils.go
@@ -52,9 +52,8 @@ func formatDate(format string, str string) string {
 	date, err := time.Parse(time.RFC3339, str)
 	if err != nil {
 		return ""
-	} else {
-		return date.Format(format)
 	}
+	return date.Format(format)
 }
 
 func contains(arr []string, str string) bool {


### PR DESCRIPTION
- Added Clip Duration in seconds (imo there's no need to use 00:00:00 format as clips are usually short)
- Added Clip creation date (same as in youtube tooltip)
- Fixed copypasted error message (`youtube template error`)
- While I was already editing my linter suggested to remove unnecessary else statements, so I did it :)

Example tooltips:

https://clips.twitch.tv/BigSavoryClamOptimizePrime
https://cdn.zneix.eu/Xu5EY3O.png
![jebaited Clip](https://cdn.zneix.eu/Xu5EY3O.png)

https://clips.twitch.tv/ExpensiveWonderfulClamArsonNoSexy
https://cdn.zneix.eu/IGfuXHi.png
![Python 4HEad](https://cdn.zneix.eu/IGfuXHi.png)

You can see that decimal points will be only added if necessary