### PR TITLE
Prettier Formatting for Twitter Tooltips

### DIFF
--- a/link_resolver_twitter.go
+++ b/link_resolver_twitter.go
@@ -22,9 +22,9 @@ const (
 
 	tweetTooltip = `<div style="text-align: left;">
 <b>{{.Name}} (@{{.Username}})</b>
-<br>
+<span style="white-space: pre-wrap; word-wrap: break-word;">
 {{.Text}}
-<br>
+</span>
 <span style="color: #808892;">{{.Likes}} likes&nbsp;•&nbsp;{{.Retweets}} retweets&nbsp;•&nbsp;{{.Timestamp}}</span>
 </div>
 `

--- a/link_resolver_twitter.go
+++ b/link_resolver_twitter.go
@@ -88,6 +88,15 @@ type twitterUserTooltipData struct {
 	Thumbnail   string
 }
 
+func humanizeNumber(number uint64) string {
+	if number < 1_000_000 {
+		return insertCommas(strconv.FormatUint(number, 10), 3)
+	}
+
+	inMillions := float64(number) / 1_000_000
+	return fmt.Sprintf("%.1fM", inMillions)
+}
+
 func getTweetIDFromURL(url *url.URL) string {
 	match := tweetRegexp.FindAllStringSubmatch(url.Path, -1)
 	if len(match) > 0 && len(match[0]) == 2 {
@@ -128,8 +137,8 @@ func buildTweetTooltip(tweet *TweetApiResponse) *tweetTooltipData {
 	data.Text = tweet.Text
 	data.Name = tweet.User.Name
 	data.Username = tweet.User.Username
-	data.Likes = insertCommas(strconv.FormatUint(tweet.Likes, 10), 3)
-	data.Retweets = insertCommas(strconv.FormatUint(tweet.Retweets, 10), 3)
+	data.Likes = humanizeNumber(tweet.Likes)
+	data.Retweets = humanizeNumber(tweet.Retweets)
 
 	timestamp, err := time.Parse("Mon Jan 2 15:04:05 -0700 2006", tweet.Timestamp)
 	data.Timestamp = timestamp.Format(timestampFormat)
@@ -186,7 +195,7 @@ func buildTwitterUserTooltip(user *TwitterUserApiResponse) *twitterUserTooltipDa
 	data.Name = user.Name
 	data.Username = user.Username
 	data.Description = user.Description
-	data.Followers = insertCommas(strconv.FormatUint(user.Followers, 10), 3)
+	data.Followers = humanizeNumber(user.Followers)
 	data.Thumbnail = user.ProfileImageUrl
 
 	return data

--- a/link_resolver_twitter.go
+++ b/link_resolver_twitter.go
@@ -31,9 +31,9 @@ const (
 
 	twitterUserTooltip = `<div style="text-align: left;">
 <b>{{.Name}} (@{{.Username}})</b>
-<br>
+<span style="white-space: pre-wrap; word-wrap: break-word;">
 {{.Description}}
-<br>
+</span>
 <span style="color: #808892;">{{.Followers}} followers</span>
 </div>
 `

--- a/link_resolver_twitter.go
+++ b/link_resolver_twitter.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -86,15 +85,6 @@ type twitterUserTooltipData struct {
 	Description string
 	Followers   string
 	Thumbnail   string
-}
-
-func humanizeNumber(number uint64) string {
-	if number < 1_000_000 {
-		return insertCommas(strconv.FormatUint(number, 10), 3)
-	}
-
-	inMillions := float64(number) / 1_000_000
-	return fmt.Sprintf("%.1fM", inMillions)
 }
 
 func getTweetIDFromURL(url *url.URL) string {

--- a/utils.go
+++ b/utils.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -46,6 +47,15 @@ func insertCommas(str string, n int) string {
 		}
 	}
 	return buffer.String()
+}
+
+func humanizeNumber(number uint64) string {
+	if number < 1_000_000 {
+		return insertCommas(strconv.FormatUint(number, 10), 3)
+	}
+
+	inMillions := float64(number) / 1_000_000
+	return fmt.Sprintf("%.1fM", inMillions)
 }
 
 func formatDate(format string, str string) string {


### PR DESCRIPTION
As suggested by @KararTY in Twitch chat, this PR adds `<style>` tags to the rich Twitter tooltips introduced in #38.
This leads to "better" behavior on some Tweets (e.g. https://twitter.com/QuoteRed/status/312215975040778240) but could potentially be annoying for other Tweets (e.g. https://twitter.com/ianchaffee/status/311940617217392640). I do not believe this is much of a problem though since you can "just" hover off a Tweet that produces a large tooltip.

Additionally, we now truncate numbers larger than one million to one decimal place (for followers, likes, and retweets). This also mimics Twitter's behavior.

<details>
<summary>Screenshots</summary>

**Old behavior:**
![chess](https://user-images.githubusercontent.com/35232120/92919933-ae1e0800-f431-11ea-8500-a84b5634c2e2.png)
![linebreaks](https://user-images.githubusercontent.com/35232120/92919941-b118f880-f431-11ea-8dde-e3ce08f86dac.png)

**New behavior:**
![chess_new](https://user-images.githubusercontent.com/35232120/92919974-c2620500-f431-11ea-9e46-1fae0efb682c.png)
![linebreaks_new](https://user-images.githubusercontent.com/35232120/92919981-c55cf580-f431-11ea-9efb-75b9fd36d63e.png)

</details>