### PR TITLE
Updated docs links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,5 +50,5 @@ Uptime: 928h5m7.937821282s - Memory: Alloc=510 MiB, TotalAlloc=17419213 MiB, Sys
 
 ## Using your self-hosted version
 If you host your own version of this API, you can modify which url Chatterino2 uses to resolve links and to resolve twitch emote sets.  
-[Change link resolver](https://github.com/Chatterino/chatterino2/blob/master/docs/ENV.md#chatterino2_link_resolver_url)  
-[Change twitch emote resolver](https://github.com/Chatterino/chatterino2/blob/master/docs/ENV.md#chatterino2_twitch_emote_set_resolver_url)  
+[Change link resolver](https://wiki.chatterino.com/Environment%20Variables/#chatterino2_link_resolver_url)  
+[Change Twitch emote resolver](https://wiki.chatterino.com/Environment%20Variables/#chatterino2_twitch_emote_set_resolver_url)


### PR DESCRIPTION
After moving all documentation to wiki.chatterino.com we forgot to update everything accordingly xd

﻿#Hacktoberfest ![FarmingCommits](https://cdn.betterttv.net/emote/5ed57f8bfdee545e3065efcb/1x)
