### PR TITLE
Updated Discord invite resolving

### DIFF
--- a/link_resolver_discord.go
+++ b/link_resolver_discord.go
@@ -194,7 +194,7 @@ func init() {
 	}
 
 	cache := newLoadingCache("discord_invites", load, 6*time.Hour) // Often calls quickly result in 429's
-	discordInviteURLRegex := regexp.MustCompile(`^(www\.)?(discord\.gg|discord(app)?\.com\/invite)\/([a-zA-Z0-9-]+)`)
+	discordInviteURLRegex := regexp.MustCompile(`^(www\.)?discord\.(gg|com\/invite)\/([a-zA-Z0-9-]+)`)
 
 	// Find links matching the Discord invite link (e.g. https://discord.com/invite/mlp, https://discord.gg/mlp)
 	customURLManagers = append(customURLManagers, customURLManager{
@@ -203,11 +203,11 @@ func init() {
 		},
 		run: func(url *url.URL) ([]byte, error) {
 			matches := discordInviteURLRegex.FindStringSubmatch(fmt.Sprintf("%s%s", strings.ToLower(url.Host), url.Path))
-			if len(matches) != 5 {
+			if len(matches) != 4 {
 				return nil, invalidDiscordInvite
 			}
 
-			inviteCode := matches[4]
+			inviteCode := matches[3]
 
 			apiResponse := cache.Get(inviteCode, nil)
 			return json.Marshal(apiResponse)

--- a/link_resolver_discord.go
+++ b/link_resolver_discord.go
@@ -19,7 +19,7 @@ import (
 
 func init() {
 	const (
-		discordInviteAPIURL = "https://discord.com/api/v6/invites/%s?with_counts=true"
+		discordInviteAPIURL = "https://discord.com/api/v8/invites/%s?with_counts=true"
 
 		discordInviteTooltip = `<div style="text-align: left;">
 <b>{{.ServerName}}</b>


### PR DESCRIPTION
Discord has announced a removal of their domain `discordapp.com` some time ago and those changes are going into effect this weekend, here's night's announcement about it:
https://cdn.zneix.eu/mg0SCQj.png
![If you read this YOU LOST ZULUL](https://cdn.zneix.eu/mg0SCQj.png)

There was also an update regarding API versions and v6 is already deprecated, soon to be discontinued, so I moved on to v8. ([Reference](https://discord.com/developers/docs/reference#api-versioning))
