### PR TITLE
Fixed Discord invites having escaped html elements

### DIFF
--- a/internal/resolvers/discord/resolver.go
+++ b/internal/resolvers/discord/resolver.go
@@ -22,7 +22,7 @@ const (
 <br><b>Server Created:</b> {{.ServerCreated}}
 <br><b>Channel:</b> {{.InviteChannel}}
 {{ if .InviterTag}}<br><b>Inviter:</b> {{.InviterTag}}{{end}}
-{{ if .ServerPerks}}<br><b>Server perks:</b> {{.ServerPerks}}{{end}}
+{{ if .ServerPerks}}<br><b>Server Perks:</b> {{.ServerPerks}}{{end}}
 <br><b>Members:</b> <span style="color: #43b581;">{{.OnlineCount}} online</span>&nbsp;•&nbsp;<span style="color: #808892;">{{.TotalCount}} total</span>
 </div>
 `

--- a/internal/resolvers/discord/resolver.go
+++ b/internal/resolvers/discord/resolver.go
@@ -21,8 +21,8 @@ const (
 <br>
 <br><b>Server Created:</b> {{.ServerCreated}}
 <br><b>Channel:</b> {{.InviteChannel}}
-{{.InviterTag}}
-{{.ServerPerks}}
+{{ if .InviterTag}}<br><b>Inviter:</b> {{.InviterTag}}{{end}}
+{{ if .ServerPerks}}<br><b>Server perks:</b> {{.ServerPerks}}{{end}}
 <br><b>Members:</b> <span style="color: #43b581;">{{.OnlineCount}} online</span>&nbsp;•&nbsp;<span style="color: #808892;">{{.TotalCount}} total</span>
 </div>
 `


### PR DESCRIPTION
Due to replacing "text/template" package with "html/template" we now escape all the html content which is good, but we forgot there was code in discord's `load.go` that dynamically adds text with html tags based on JSON API response. I fiddled around with those {{.}} keywords and found some improvements that will keep us from adding html tags in a dirty hacky way and fixes the issue presented below:

Old (bugged) behavoir:
![https://cdn.zneix.eu/q8Hh5mh.png](https://cdn.zneix.eu/9Ey8SQx.png)

Updated behavoir:
![https://cdn.zneix.eu/q8Hh5mh.png](https://cdn.zneix.eu/EDqItTX.png)

Also made some slight changes to discord invite tooltip and variable names to make the old code cleaner and more reasonable.
