### PR TITLE
Improved FrankerFaceZ emote link regex

### DIFF
--- a/internal/resolvers/frankerfacez/resolver.go
+++ b/internal/resolvers/frankerfacez/resolver.go
@@ -28,7 +28,7 @@ var (
 		"www.frankerfacez.com": {},
 	}
 
-	emotePathRegex = regexp.MustCompile(`/emoticon/([0-9]+)-.+?`)
+	emotePathRegex = regexp.MustCompile(`/emoticon/([0-9]+)(-(.+)?)?$`)
 
 	emoteCache = cache.New("ffz_emotes", load, 1*time.Hour)
 

--- a/internal/resolvers/frankerfacez/run_v1.go
+++ b/internal/resolvers/frankerfacez/run_v1.go
@@ -7,7 +7,7 @@ import (
 
 func run(url *url.URL) ([]byte, error) {
 	matches := emotePathRegex.FindStringSubmatch(url.Path)
-	if len(matches) != 2 {
+	if len(matches) != 4 {
 		return nil, errInvalidFrankerFaceZEmotePath
 	}
 


### PR DESCRIPTION
Turns out that links like https://www.frankerfacez.com/emoticon/211702- and https://www.frankerfacez.com/emoticon/211702 are also valid, so why not provide rich tooltips for them ![neutral emote KKona](https://cdn.betterttv.net/emote/566ca04265dbbdab32ec054a/1x)
