### PR TITLE
Stop double building CI stuff

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,12 @@
+---
 name: Build
-on: [push, pull_request]
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,21 +17,21 @@ jobs:
         go: [1.14, 1.15]
 
     steps:
-    - name: Set up Go
-      uses: actions/setup-go@v2.1.3
-      with:
-        go-version: ${{ matrix.go }}
-      id: go
+      - name: Set up Go
+        uses: actions/setup-go@v2.1.3
+        with:
+          go-version: ${{ matrix.go }}
+        id: go
 
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v2.3.4
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2.3.4
 
-    - name: Get dependencies
-      run: |
-        go get -v -t -d ./...
+      - name: Get dependencies
+        run: |
+          go get -v -t -d ./...
 
-    - name: Build
-      run: go build -v
+      - name: Build
+        run: go build -v
 
-    - name: Test
-      run: go test -v ./...
+      - name: Test
+        run: go test -v ./...


### PR DESCRIPTION
- Ensure we don't build on non-master branches unless they're pull requests (removes duplicate builds)
- Reformat build.yml
