### PR TITLE
Rich Responses for Wikipedia Links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Added support for Wikipedia article links. (#92)
 - Fixed an issue where OpenGraph descriptions were not HTML-sanitized. (#90)
 - Added support for imgur image links. (#81)
 - Added support for FrankerFaceZ emote links. (#57)

--- a/internal/resolvers/default/resolver.go
+++ b/internal/resolvers/default/resolver.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Chatterino/api/internal/resolvers/supinic"
 	"github.com/Chatterino/api/internal/resolvers/twitch"
 	"github.com/Chatterino/api/internal/resolvers/twitter"
+	"github.com/Chatterino/api/internal/resolvers/wikipedia"
 	"github.com/Chatterino/api/internal/resolvers/youtube"
 	"github.com/Chatterino/api/pkg/cache"
 	"github.com/Chatterino/api/pkg/resolver"
@@ -84,6 +85,7 @@ func New(baseURL string) *R {
 	r.customResolvers = append(r.customResolvers, supinic.New()...)
 	r.customResolvers = append(r.customResolvers, twitch.New()...)
 	r.customResolvers = append(r.customResolvers, imgur.New()...)
+	r.customResolvers = append(r.customResolvers, wikipedia.New()...)
 
 	return r
 }

--- a/internal/resolvers/wikipedia/check.go
+++ b/internal/resolvers/wikipedia/check.go
@@ -1,0 +1,15 @@
+package wikipedia
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/Chatterino/api/pkg/utils"
+)
+
+func check(url *url.URL) bool {
+	isWikipedia := utils.IsSubdomainOf(url, "wikipedia.org")
+	isWikiArticle := strings.HasPrefix(url.Path, "/wiki/")
+
+	return isWikipedia && isWikiArticle
+}

--- a/internal/resolvers/wikipedia/helpers.go
+++ b/internal/resolvers/wikipedia/helpers.go
@@ -61,8 +61,6 @@ func getPageInfo(urlString string) (*wikipediaTooltipData, error) {
 
 	if pageInfo.Description != nil {
 		tooltipData.Description = utils.TruncateString(*pageInfo.Description, maxDescriptionLength)
-	} else {
-		tooltipData.Description = ""
 	}
 
 	if pageInfo.Thumbnail != nil {

--- a/internal/resolvers/wikipedia/helpers.go
+++ b/internal/resolvers/wikipedia/helpers.go
@@ -1,0 +1,93 @@
+package wikipedia
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/Chatterino/api/pkg/cache"
+	"github.com/Chatterino/api/pkg/resolver"
+	"github.com/Chatterino/api/pkg/utils"
+)
+
+func getPageInfo(urlString string) (*wikipediaTooltipData, error) {
+	u, err := url.Parse(urlString)
+	if err != nil {
+		return nil, err
+	}
+
+	// Since the Wikipedia API is locale-dependant, we need the locale code.
+	// For example, if you want to resolve a de.wikipedia.org link, you need
+	// to ping the DE API endpoint.
+	localeMatch := localeRegexp.FindStringSubmatch(u.Hostname())
+	if len(localeMatch) != 2 {
+		return nil, errLocaleMatch
+	}
+
+	localeCode := localeMatch[1]
+
+	titleMatch := titleRegexp.FindStringSubmatch(u.Path)
+	if len(titleMatch) != 2 {
+		return nil, errTitleMatch
+	}
+
+	canonicalName := titleMatch[1]
+
+	requestURL := fmt.Sprintf(endpointURL, localeCode, canonicalName)
+
+	resp, err := resolver.RequestGET(requestURL)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("bad status: %d", resp.StatusCode)
+	}
+
+	var pageInfo *wikipediaAPIResponse
+	if err = json.NewDecoder(resp.Body).Decode(&pageInfo); err != nil {
+		return nil, err
+	}
+
+	// Transform API response into our tooltip model for Wikipedia links
+	tooltipData := &wikipediaTooltipData{}
+
+	tooltipData.Title = utils.TruncateString(pageInfo.Titles.Display, maxTitleLength)
+	tooltipData.Extract = utils.TruncateString(pageInfo.Extract, maxExtractLength)
+
+	if pageInfo.Description != nil {
+		tooltipData.Description = utils.TruncateString(*pageInfo.Description, maxDescriptionLength)
+	} else {
+		tooltipData.Description = ""
+	}
+
+	if pageInfo.Thumbnail != nil {
+		tooltipData.ThumbnailURL = pageInfo.Thumbnail.URL
+	}
+
+	return tooltipData, nil
+}
+
+func buildTooltip(pageInfo *wikipediaTooltipData) (interface{}, time.Duration, error) {
+	var tooltip bytes.Buffer
+
+	if err := wikipediaTooltipTemplate.Execute(&tooltip, pageInfo); err != nil {
+		return &resolver.Response{
+			Status:  http.StatusInternalServerError,
+			Message: "Wikipedia template error: " + resolver.CleanResponse(err.Error()),
+		}, cache.NoSpecialDur, nil
+	}
+
+	return response{
+		resolverResponse: &resolver.Response{
+			Status:    http.StatusOK,
+			Tooltip:   url.PathEscape(tooltip.String()),
+			Thumbnail: pageInfo.ThumbnailURL,
+		},
+		err: nil,
+	}, cache.NoSpecialDur, nil
+}

--- a/internal/resolvers/wikipedia/helpers.go
+++ b/internal/resolvers/wikipedia/helpers.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"html"
 	"net/http"
 	"net/url"
 	"time"
@@ -56,11 +57,15 @@ func getPageInfo(urlString string) (*wikipediaTooltipData, error) {
 	// Transform API response into our tooltip model for Wikipedia links
 	tooltipData := &wikipediaTooltipData{}
 
-	tooltipData.Title = utils.TruncateString(pageInfo.Titles.Display, maxTitleLength)
-	tooltipData.Extract = utils.TruncateString(pageInfo.Extract, maxExtractLength)
+	sanitizedTitle := html.EscapeString(pageInfo.Titles.Display)
+	tooltipData.Title = utils.TruncateString(sanitizedTitle, maxTitleLength)
+
+	sanitizedExtract := html.EscapeString(pageInfo.Extract)
+	tooltipData.Extract = utils.TruncateString(sanitizedExtract, maxExtractLength)
 
 	if pageInfo.Description != nil {
-		tooltipData.Description = utils.TruncateString(*pageInfo.Description, maxDescriptionLength)
+		sanitizedDescription := html.EscapeString(*pageInfo.Description)
+		tooltipData.Description = utils.TruncateString(sanitizedDescription, maxDescriptionLength)
 	}
 
 	if pageInfo.Thumbnail != nil {

--- a/internal/resolvers/wikipedia/helpers.go
+++ b/internal/resolvers/wikipedia/helpers.go
@@ -75,13 +75,15 @@ func getPageInfo(urlString string) (*wikipediaTooltipData, error) {
 	return tooltipData, nil
 }
 
-func buildTooltip(pageInfo *wikipediaTooltipData) (interface{}, time.Duration, error) {
+func buildTooltip(pageInfo *wikipediaTooltipData) (response, time.Duration, error) {
 	var tooltip bytes.Buffer
 
 	if err := wikipediaTooltipTemplate.Execute(&tooltip, pageInfo); err != nil {
-		return &resolver.Response{
-			Status:  http.StatusInternalServerError,
-			Message: "Wikipedia template error: " + resolver.CleanResponse(err.Error()),
+		return response{
+			resolverResponse: &resolver.Response{
+				Status:  http.StatusInternalServerError,
+				Message: "Wikipedia template error: " + resolver.CleanResponse(err.Error()),
+			}, err: nil,
 		}, cache.NoSpecialDur, nil
 	}
 

--- a/internal/resolvers/wikipedia/load.go
+++ b/internal/resolvers/wikipedia/load.go
@@ -1,0 +1,36 @@
+package wikipedia
+
+import (
+	"net/http"
+	"time"
+
+	"log"
+
+	"github.com/Chatterino/api/pkg/cache"
+	"github.com/Chatterino/api/pkg/resolver"
+)
+
+type response struct {
+	resolverResponse *resolver.Response
+	err              error
+}
+
+func load(urlString string, r *http.Request) (interface{}, time.Duration, error) {
+	log.Println("[Wikipedia] GET", urlString)
+
+	tooltipData, err := getPageInfo(urlString)
+
+	if err != nil {
+		log.Println("[Wikipedia] ERROR resolving URL", urlString, ":", err.Error())
+
+		return response{
+			resolverResponse: &resolver.Response{
+				Status:  http.StatusOK,
+				Tooltip: "Error getting Wikipedia API information for URL",
+			},
+			err: resolver.ErrDontHandle,
+		}, cache.NoSpecialDur, nil
+	}
+
+	return buildTooltip(tooltipData)
+}

--- a/internal/resolvers/wikipedia/model.go
+++ b/internal/resolvers/wikipedia/model.go
@@ -22,7 +22,7 @@ type wikipediaTooltipData struct {
 }
 
 const wikipediaTooltip = `<div style="text-align: left;">
-<b>{{.Title}}{{ if .Description }}&nbsp;•&nbsp;{{.Description}}{{ end }}</b><br />
+<b>{{.Title}}{{ if .Description }}&nbsp;•&nbsp;{{.Description}}{{ end }}</b><br>
 {{.Extract}}
 </div>
 `

--- a/internal/resolvers/wikipedia/model.go
+++ b/internal/resolvers/wikipedia/model.go
@@ -1,0 +1,28 @@
+package wikipedia
+
+// The `Thumbnail` and `Description` fields are declared as pointers because
+// they are not strictly required by the schema and may be omitted for some
+// pages. In these cases, the fields will be nil.
+type wikipediaAPIResponse struct {
+	Titles struct {
+		Display string `json:"display"`
+	} `json:"titles"`
+	Extract   string `json:"extract"`
+	Thumbnail *struct {
+		URL string `json:"source"`
+	} `json:"thumbnail"`
+	Description *string `json:"description"`
+}
+
+type wikipediaTooltipData struct {
+	Title        string
+	Description  string
+	Extract      string
+	ThumbnailURL string
+}
+
+const wikipediaTooltip = `<div style="text-align: left;">
+<b>{{.Title}}{{ if .Description }}&nbsp;•&nbsp;{{.Description}}{{ end }}</b><br />
+{{.Extract}}
+</div>
+`

--- a/internal/resolvers/wikipedia/resolver.go
+++ b/internal/resolvers/wikipedia/resolver.go
@@ -1,0 +1,42 @@
+package wikipedia
+
+import (
+	"errors"
+	"regexp"
+	"text/template"
+	"time"
+
+	"github.com/Chatterino/api/pkg/cache"
+	"github.com/Chatterino/api/pkg/resolver"
+)
+
+var (
+	localeRegexp = regexp.MustCompile(`(?i)([a-z]+)\.wikipedia\.org`)
+	titleRegexp  = regexp.MustCompile(`\/wiki\/(.+)`)
+
+	wikipediaTooltipTemplate = template.Must(template.New("wikipediaTooltipTemplate").Parse(wikipediaTooltip))
+
+	wikipediaCache = cache.New("wikipedia", load, 1*time.Hour)
+
+	errLocaleMatch = errors.New("could not find locale from URL")
+	errTitleMatch  = errors.New("could not find title from URL")
+)
+
+const (
+	endpointURL = "https://%s.wikipedia.org/api/rest_v1/page/summary/%s?redirect=false"
+
+	// TODO: Replace these with shared constants once implemented
+	maxTitleLength       = 60
+	maxDescriptionLength = 60
+	maxExtractLength     = 200
+)
+
+func New() (resolvers []resolver.CustomURLManager) {
+	resolvers = append(resolvers, resolver.CustomURLManager{
+		Check: check,
+
+		Run: run,
+	})
+
+	return
+}

--- a/internal/resolvers/wikipedia/run.go
+++ b/internal/resolvers/wikipedia/run.go
@@ -1,0 +1,20 @@
+package wikipedia
+
+import (
+	"encoding/json"
+	"errors"
+	"net/url"
+)
+
+func run(url *url.URL) ([]byte, error) {
+	wikiResponse, ok := wikipediaCache.Get(url.String(), nil).(response)
+	if !ok {
+		return nil, errors.New("wikipedia cache load function is broken")
+	}
+
+	if wikiResponse.err != nil {
+		return nil, wikiResponse.err
+	}
+
+	return json.Marshal(wikiResponse.resolverResponse)
+}

--- a/pkg/utils/url.go
+++ b/pkg/utils/url.go
@@ -31,3 +31,14 @@ func UnescapeURLArgument(r *http.Request, key string) (string, error) {
 
 	return url, nil
 }
+
+// IsSubdomainOf checks whether `url` is a subdomain of `parent`
+func IsSubdomainOf(url *url.URL, parent string) bool {
+	// We use Hostname() as that strips possible port numbers (relevant for the suffix check)
+	hostname := url.Hostname()
+
+	same := (hostname == parent)
+	trueSub := strings.HasSuffix(hostname, "."+parent)
+
+	return same || trueSub
+}


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Adds rich responses for Wikipedia links, as outlined in #91.
Merging this closes #91.

**Known limitations:**
- Links of the format `https://en.wikipedia.org/?curid=33362853` are handled by the default resolver instead. I cannot seem to find an endpoint for this link format. If anyone comes across something, please let me know.
- Constants regarding maximum length of titles and descriptions are duplicated in the Wikipedia resolver from the default resolver. I did not feel comfortable normalizing constants so I put a TODO on instead.

**Open questions:**
- What is an appropriate cache duration? We could probably get away with longer cache durations for Wikipedia articles as they change rarely. Currently I followed the commonly used value of one hour.
- From experimentation, the maximum dimensions for thumbnails returned by the API endpoint seems to be 320×320 (although I could not find any official documentation on this). This is pretty close to the 300 pixel maximum width/height used for the default link resolver so I decided to not resize anything here. Let me know if you'd like to have thumbnails resized anyway.

Feel free to leave nitpicky feedback, especially in regards to the package/directory structure. I tried to keep close to the way the imgur resolver is laid out but I'm open to any suggestions.
