### PR TITLE
Normalize date formatting and domain checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Twitter resolver timestamp date format changed from `Jan 2 2006` to `02 Jan 2006`
 - Dev: Moved main package from root directory to `/cmd/api` (#104)
 - Dev: Replaced `gorilla/mux` with `go-chi/chi`. This change requires the URL parameters to be percent-encoded, specifically the slashes. (#99)
 - Added support for Livestreamfails clip links. (#98)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- Twitter resolver timestamp date format changed from `Jan 2 2006` to `02 Jan 2006`
+- Twitter resolver timestamp date format changed from `Jan 2 2006` to `02 Jan 2006` (#105)
 - Dev: Moved main package from root directory to `/cmd/api` (#104)
 - Dev: Replaced `gorilla/mux` with `go-chi/chi`. This change requires the URL parameters to be percent-encoded, specifically the slashes. (#99)
 - Added support for Livestreamfails clip links. (#98)

--- a/internal/resolvers/default/model.go
+++ b/internal/resolvers/default/model.go
@@ -4,6 +4,7 @@ import (
 	"html"
 	"net/http"
 
+	"github.com/Chatterino/api/pkg/humanize"
 	"github.com/Chatterino/api/pkg/resolver"
 	"github.com/Chatterino/api/pkg/utils"
 	"github.com/PuerkitoBio/goquery"
@@ -17,7 +18,7 @@ type tooltipData struct {
 }
 
 func (d *tooltipData) Truncate() {
-	d.Title = utils.TruncateString(d.Title, MaxTitleLength)
+	d.Title = humanize.Title(d.Title)
 	d.Description = utils.TruncateString(d.Description, MaxDescriptionLength)
 }
 

--- a/internal/resolvers/default/model.go
+++ b/internal/resolvers/default/model.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/Chatterino/api/pkg/humanize"
 	"github.com/Chatterino/api/pkg/resolver"
-	"github.com/Chatterino/api/pkg/utils"
 	"github.com/PuerkitoBio/goquery"
 )
 
@@ -19,7 +18,7 @@ type tooltipData struct {
 
 func (d *tooltipData) Truncate() {
 	d.Title = humanize.Title(d.Title)
-	d.Description = utils.TruncateString(d.Description, MaxDescriptionLength)
+	d.Description = humanize.Description(d.Description)
 }
 
 func (d *tooltipData) Sanitize() {

--- a/internal/resolvers/default/resolver.go
+++ b/internal/resolvers/default/resolver.go
@@ -31,9 +31,6 @@ const (
 <span>{{.Description}}</span><hr>
 {{end}}
 <b>URL:</b> {{.URL}}</div>`
-
-	// MaxDescriptionLength describes the maximum length of an og:description when returned from the default link resolver
-	MaxDescriptionLength = 200
 )
 
 var (

--- a/internal/resolvers/default/resolver.go
+++ b/internal/resolvers/default/resolver.go
@@ -32,9 +32,6 @@ const (
 {{end}}
 <b>URL:</b> {{.URL}}</div>`
 
-	// MaxTitleLength describes the maximum length of a title when returned from the default link resolver
-	MaxTitleLength = 60
-
 	// MaxDescriptionLength describes the maximum length of an og:description when returned from the default link resolver
 	MaxDescriptionLength = 200
 )

--- a/internal/resolvers/discord/load.go
+++ b/internal/resolvers/discord/load.go
@@ -67,7 +67,7 @@ func load(inviteCode string, r *http.Request) (interface{}, time.Duration, error
 	// Comverting Discord Snowflake to date string
 	// Reference https://discord.com/developers/docs/reference#snowflakes
 	snowflake, _ := strconv.ParseInt(jsonResponse.Guild.ID, 10, 64)
-	dateFromSnowflake := time.Unix(snowflake>>22/1000+1420066800, 0).Format("02 Jan 2006")
+	dateFromSnowflake := humanize.CreationDateUnix(snowflake>>22/1000 + 1420066800)
 
 	// Adding row with inviter's user tag if present
 	userTag := ""

--- a/internal/resolvers/imgur/check.go
+++ b/internal/resolvers/imgur/check.go
@@ -2,13 +2,10 @@ package imgur
 
 import (
 	"net/url"
-	"strings"
+
+	"github.com/Chatterino/api/pkg/utils"
 )
 
 func check(url *url.URL) bool {
-	// TODO: Make a shared helper function that does basically this.
-	// helpers.IsSubdomainOf(url.Host, "imgur.com")
-	isImgur := strings.HasSuffix(url.Host, ".imgur.com") || url.Host == "imgur.com"
-
-	return isImgur
+	return utils.IsSubdomainOf(url, "imgur.com")
 }

--- a/internal/resolvers/imgur/helpers.go
+++ b/internal/resolvers/imgur/helpers.go
@@ -5,24 +5,17 @@ import (
 	"net/url"
 	"path"
 	"strings"
-	"time"
 
+	"github.com/Chatterino/api/pkg/humanize"
 	"github.com/koffeinsource/go-imgur"
 )
-
-// format the incoming "created at" timestamp from the imgur api to our standard created at format
-// see top of resolver.go for the format
-func formatTimestamp(datetime int64) string {
-	t := time.Unix(datetime, 0)
-	return t.Format(timestampFormat)
-}
 
 // Make a miniImage struct from a Gallery Image Info go-imgur struct
 func makeMiniImageFromGImage(imageInfo imgur.GalleryImageInfo) miniImage {
 	mini := miniImage{
 		Title:       imageInfo.Title,
 		Description: imageInfo.Description,
-		UploadDate:  formatTimestamp(int64(imageInfo.Datetime)),
+		UploadDate:  humanize.CreationDateTimeUnix(int64(imageInfo.Datetime)),
 		Nsfw:        imageInfo.Nsfw,
 		Animated:    imageInfo.Animated,
 		Album:       true,
@@ -43,7 +36,7 @@ func makeMiniImage(imageInfo imgur.ImageInfo) miniImage {
 	mini := miniImage{
 		Title:       imageInfo.Title,
 		Description: imageInfo.Description,
-		UploadDate:  formatTimestamp(int64(imageInfo.Datetime)),
+		UploadDate:  humanize.CreationDateTimeUnix(int64(imageInfo.Datetime)),
 		Nsfw:        imageInfo.Nsfw,
 		Animated:    imageInfo.Animated,
 		Album:       true,

--- a/internal/resolvers/imgur/resolver.go
+++ b/internal/resolvers/imgur/resolver.go
@@ -13,8 +13,6 @@ import (
 )
 
 var (
-	timestampFormat = "Jan 2 2006 • 15:04 UTC"
-
 	// max size of an image before we use a small thumbnail of it
 	maxRawImageSize = 50 * 1024
 

--- a/internal/resolvers/livestreamfails/load.go
+++ b/internal/resolvers/livestreamfails/load.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/Chatterino/api/pkg/cache"
+	"github.com/Chatterino/api/pkg/humanize"
 	"github.com/Chatterino/api/pkg/resolver"
 )
 
@@ -59,7 +60,7 @@ func load(clipID string, r *http.Request) (interface{}, time.Duration, error) {
 		RedditScore:  clipData.RedditScore,
 		Platform:     strings.Title(strings.ToLower(clipData.SourcePlatform)),
 		StreamerName: clipData.Streamer.Label,
-		CreationDate: clipData.CreatedAt.Format("02 Jan 2006"),
+		CreationDate: humanize.CreationDate(clipData.CreatedAt),
 	}
 
 	// Build a tooltip using the tooltip template (see tooltipTemplate) with the data we massaged above

--- a/internal/resolvers/livestreamfails/resolver.go
+++ b/internal/resolvers/livestreamfails/resolver.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Chatterino/api/pkg/cache"
 	"github.com/Chatterino/api/pkg/resolver"
+	"github.com/Chatterino/api/pkg/utils"
 )
 
 const (
@@ -43,7 +44,7 @@ func New() (resolvers []resolver.CustomURLManager) {
 	// Find clips that look like https://livestreamfails.com/clip/IdHere
 	resolvers = append(resolvers, resolver.CustomURLManager{
 		Check: func(url *url.URL) bool {
-			if !strings.HasSuffix(url.Host, "livestreamfails.com") {
+			if !utils.IsSubdomainOf(url, "livestreamfails.com") {
 				return false
 			}
 

--- a/internal/resolvers/supinic/check.go
+++ b/internal/resolvers/supinic/check.go
@@ -2,13 +2,12 @@ package supinic
 
 import (
 	"net/url"
-	"strings"
+
+	"github.com/Chatterino/api/pkg/utils"
 )
 
 func check(url *url.URL) bool {
-	host := strings.ToLower(url.Host)
-
-	if _, ok := trackListDomains[host]; !ok {
+	if !utils.IsDomains(url, trackListDomains) {
 		return false
 	}
 

--- a/internal/resolvers/supinic/load.go
+++ b/internal/resolvers/supinic/load.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/Chatterino/api/pkg/cache"
+	"github.com/Chatterino/api/pkg/humanize"
 	"github.com/Chatterino/api/pkg/resolver"
 )
 
@@ -71,21 +72,13 @@ func load(rawTrackID string, r *http.Request) (interface{}, time.Duration, error
 		prettyAuthors = "unknown"
 	}
 
-	// formatDuration() cannot be use here as that parses an ISO duration
-	duration := time.Duration(trackData.Duration) * time.Second
-	hours := duration / time.Hour
-	duration -= hours * time.Hour
-	minutes := duration / time.Minute
-	duration -= minutes * time.Minute
-	seconds := duration / time.Second
-
 	// Build tooltip data from the API response
 	data := TooltipData{
 		ID:         trackData.ID,
 		Name:       trackData.Name,
 		AuthorName: prettyAuthors,
 		Tags:       strings.Join(trackData.Tags, ", "),
-		Duration:   fmt.Sprintf("%02d:%02d:%02d", hours, minutes, seconds),
+		Duration:   humanize.Duration(time.Duration(trackData.Duration) * time.Second),
 	}
 
 	// Build a tooltip using the tooltip template (see tooltipTemplate) with the data we massaged above

--- a/internal/resolvers/twitch/load.go
+++ b/internal/resolvers/twitch/load.go
@@ -2,7 +2,6 @@ package twitch
 
 import (
 	"bytes"
-	"fmt"
 	"log"
 	"net/http"
 	"net/url"
@@ -24,7 +23,7 @@ func load(clipSlug string, r *http.Request) (interface{}, time.Duration, error) 
 		Title:        clip.Title,
 		AuthorName:   clip.Curator.DisplayName,
 		ChannelName:  clip.Broadcaster.DisplayName,
-		Duration:     fmt.Sprintf("%g%s", clip.Duration, "s"),
+		Duration:     humanize.DurationSeconds(time.Duration(clip.Duration) * time.Second),
 		CreationDate: clip.CreatedAt.Format("02 Jan 2006"),
 		Views:        humanize.Number(uint64(clip.Views)),
 	}

--- a/internal/resolvers/twitch/load.go
+++ b/internal/resolvers/twitch/load.go
@@ -24,7 +24,7 @@ func load(clipSlug string, r *http.Request) (interface{}, time.Duration, error) 
 		AuthorName:   clip.Curator.DisplayName,
 		ChannelName:  clip.Broadcaster.DisplayName,
 		Duration:     humanize.DurationSeconds(time.Duration(clip.Duration) * time.Second),
-		CreationDate: clip.CreatedAt.Format("02 Jan 2006"),
+		CreationDate: humanize.CreationDate(clip.CreatedAt),
 		Views:        humanize.Number(uint64(clip.Views)),
 	}
 

--- a/internal/resolvers/twitch/resolver.go
+++ b/internal/resolvers/twitch/resolver.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Chatterino/api/pkg/cache"
 	"github.com/Chatterino/api/pkg/resolver"
+	"github.com/Chatterino/api/pkg/utils"
 	"github.com/dankeroni/gotwitch"
 )
 
@@ -44,7 +45,7 @@ func New() (resolvers []resolver.CustomURLManager) {
 	// Find clips that look like https://clips.twitch.tv/SlugHere
 	resolvers = append(resolvers, resolver.CustomURLManager{
 		Check: func(url *url.URL) bool {
-			return strings.HasSuffix(url.Host, "clips.twitch.tv")
+			return utils.IsDomain(url, "clips.twitch.tv")
 		},
 		Run: func(url *url.URL) ([]byte, error) {
 			pathParts := strings.Split(strings.TrimPrefix(url.Path, "/"), "/")

--- a/internal/resolvers/twitter/api.go
+++ b/internal/resolvers/twitter/api.go
@@ -29,8 +29,9 @@ func buildTweetTooltip(tweet *TweetApiResponse) *tweetTooltipData {
 	data.Likes = humanize.Number(tweet.Likes)
 	data.Retweets = humanize.Number(tweet.Retweets)
 
+	// TODO: what time format is this exactly? can we move to humanize a la CreationDteRFC3339?
 	timestamp, err := time.Parse("Mon Jan 2 15:04:05 -0700 2006", tweet.Timestamp)
-	data.Timestamp = timestamp.Format(timestampFormat)
+	data.Timestamp = humanize.CreationDateTime(timestamp)
 	if err != nil {
 		log.Println(err.Error())
 		data.Timestamp = ""

--- a/internal/resolvers/twitter/check.go
+++ b/internal/resolvers/twitter/check.go
@@ -2,13 +2,12 @@ package twitter
 
 import (
 	"net/url"
-	"strings"
+
+	"github.com/Chatterino/api/pkg/utils"
 )
 
 func check(url *url.URL) bool {
-	isTwitter := (strings.HasSuffix(url.Host, ".twitter.com") || url.Host == "twitter.com")
-
-	if !isTwitter {
+	if !utils.IsSubdomainOf(url, "twitter.com") {
 		return false
 	}
 

--- a/internal/resolvers/twitter/resolver.go
+++ b/internal/resolvers/twitter/resolver.go
@@ -13,8 +13,6 @@ import (
 )
 
 const (
-	timestampFormat = "Jan 2 2006 • 15:04 UTC"
-
 	tweetTooltip = `<div style="text-align: left;">
 <b>{{.Name}} (@{{.Username}})</b>
 <span style="white-space: pre-wrap; word-wrap: break-word;">

--- a/internal/resolvers/wikipedia/helpers.go
+++ b/internal/resolvers/wikipedia/helpers.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"github.com/Chatterino/api/pkg/cache"
+	"github.com/Chatterino/api/pkg/humanize"
 	"github.com/Chatterino/api/pkg/resolver"
-	"github.com/Chatterino/api/pkg/utils"
 )
 
 func getPageInfo(urlString string) (*wikipediaTooltipData, error) {
@@ -58,14 +58,14 @@ func getPageInfo(urlString string) (*wikipediaTooltipData, error) {
 	tooltipData := &wikipediaTooltipData{}
 
 	sanitizedTitle := html.EscapeString(pageInfo.Titles.Display)
-	tooltipData.Title = utils.TruncateString(sanitizedTitle, maxTitleLength)
+	tooltipData.Title = humanize.Title(sanitizedTitle)
 
 	sanitizedExtract := html.EscapeString(pageInfo.Extract)
-	tooltipData.Extract = utils.TruncateString(sanitizedExtract, maxExtractLength)
+	tooltipData.Extract = humanize.Description(sanitizedExtract)
 
 	if pageInfo.Description != nil {
 		sanitizedDescription := html.EscapeString(*pageInfo.Description)
-		tooltipData.Description = utils.TruncateString(sanitizedDescription, maxDescriptionLength)
+		tooltipData.Description = humanize.ShortDescription(sanitizedDescription)
 	}
 
 	if pageInfo.Thumbnail != nil {

--- a/internal/resolvers/wikipedia/resolver.go
+++ b/internal/resolvers/wikipedia/resolver.go
@@ -24,11 +24,6 @@ var (
 
 const (
 	endpointURL = "https://%s.wikipedia.org/api/rest_v1/page/summary/%s?redirect=false"
-
-	// TODO: Replace these with shared constants once implemented
-	maxTitleLength       = 60
-	maxDescriptionLength = 60
-	maxExtractLength     = 200
 )
 
 func New() (resolvers []resolver.CustomURLManager) {

--- a/internal/resolvers/youtube/load.go
+++ b/internal/resolvers/youtube/load.go
@@ -3,29 +3,15 @@ package youtube
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"log"
 	"net/http"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/Chatterino/api/pkg/cache"
 	"github.com/Chatterino/api/pkg/humanize"
 	"github.com/Chatterino/api/pkg/resolver"
 )
-
-func parseDuration(dur string) string {
-	dur = strings.ToLower(dur)
-	dur = strings.Replace(dur, "pt", "", 1)
-	d, _ := time.ParseDuration(dur)
-	h := d / time.Hour
-	d -= h * time.Hour
-	m := d / time.Minute
-	d -= m * time.Minute
-	s := d / time.Second
-	return fmt.Sprintf("%02d:%02d:%02d", h, m, s)
-}
 
 func load(videoID string, r *http.Request) (interface{}, time.Duration, error) {
 	youtubeVideoParts := []string{
@@ -56,7 +42,7 @@ func load(videoID string, r *http.Request) (interface{}, time.Duration, error) {
 	data := youtubeTooltipData{
 		Title:        video.Snippet.Title,
 		ChannelTitle: video.Snippet.ChannelTitle,
-		Duration:     parseDuration(video.ContentDetails.Duration),
+		Duration:     humanize.DurationPT(video.ContentDetails.Duration),
 		PublishDate:  humanize.CreationDateRFC3339(video.Snippet.PublishedAt),
 		Views:        humanize.Number(video.Statistics.ViewCount),
 		LikeCount:    humanize.Number(video.Statistics.LikeCount),

--- a/internal/resolvers/youtube/load.go
+++ b/internal/resolvers/youtube/load.go
@@ -57,7 +57,7 @@ func load(videoID string, r *http.Request) (interface{}, time.Duration, error) {
 		Title:        video.Snippet.Title,
 		ChannelTitle: video.Snippet.ChannelTitle,
 		Duration:     parseDuration(video.ContentDetails.Duration),
-		PublishDate:  humanize.Date("02 Jan 2006", video.Snippet.PublishedAt),
+		PublishDate:  humanize.CreationDateRFC3339(video.Snippet.PublishedAt),
 		Views:        humanize.Number(video.Statistics.ViewCount),
 		LikeCount:    humanize.Number(video.Statistics.LikeCount),
 		DislikeCount: humanize.Number(video.Statistics.DislikeCount),

--- a/internal/resolvers/youtube/resolver.go
+++ b/internal/resolvers/youtube/resolver.go
@@ -7,11 +7,11 @@ import (
 	"log"
 	"net/url"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/Chatterino/api/pkg/cache"
 	"github.com/Chatterino/api/pkg/resolver"
+	"github.com/Chatterino/api/pkg/utils"
 
 	"google.golang.org/api/option"
 	youtubeAPI "google.golang.org/api/youtube/v3"
@@ -53,7 +53,7 @@ func New() (resolvers []resolver.CustomURLManager) {
 
 	resolvers = append(resolvers, resolver.CustomURLManager{
 		Check: func(url *url.URL) bool {
-			return strings.HasSuffix(url.Host, ".youtube.com") || url.Host == "youtube.com"
+			return utils.IsSubdomainOf(url, "youtube.com")
 		},
 		Run: func(url *url.URL) ([]byte, error) {
 			videoID := getYoutubeVideoIDFromURL(url)

--- a/pkg/humanize/date.go
+++ b/pkg/humanize/date.go
@@ -1,6 +1,9 @@
 package humanize
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 // Date converts a date from a string in the RFC3339 format into one specified in the format string
 func Date(format string, str string) string {
@@ -9,4 +12,21 @@ func Date(format string, str string) string {
 		return ""
 	}
 	return date.Format(format)
+}
+
+// Duration takes a `time.Duration` and converts it to the nearest-second string output
+// Example output: 01:59:59
+func Duration(duration time.Duration) string {
+	// Truncate away any non-second data
+	duration = duration.Truncate(1 * time.Second)
+
+	var hours, minutes, seconds time.Duration
+
+	hours = duration / time.Hour
+	duration -= hours * time.Hour
+	minutes = duration / time.Minute
+	duration -= minutes * time.Minute
+	seconds = duration / time.Second
+
+	return fmt.Sprintf("%02d:%02d:%02d", hours, minutes, seconds)
 }

--- a/pkg/humanize/date.go
+++ b/pkg/humanize/date.go
@@ -59,3 +59,10 @@ func CreationDateRFC3339(str string) string {
 func CreationDateTime(t time.Time) string {
 	return t.Format("02 Jan 2006 • 15:04 UTC")
 }
+
+// CreationDateTimeUnix parses the incoming `int64` as a unix timestamp and then formats it with the CreationDateTime function
+// Example output: 02 Jan 2006 • 15:04 UTC
+func CreationDateTimeUnix(unix int64) string {
+	t := time.Unix(unix, 0)
+	return CreationDateTime(t)
+}

--- a/pkg/humanize/date.go
+++ b/pkg/humanize/date.go
@@ -44,3 +44,9 @@ func DurationSeconds(duration time.Duration) string {
 
 	return fmt.Sprintf("%gs", duration.Seconds())
 }
+
+// CreationDate returns the `time.Time`'s date formatted in the `02 Jan 2006` format
+// Example output: 02 Dec 2016
+func CreationDate(t time.Time) string {
+	return t.Format("02 Jan 2006")
+}

--- a/pkg/humanize/date.go
+++ b/pkg/humanize/date.go
@@ -53,3 +53,9 @@ func CreationDateRFC3339(str string) string {
 	}
 	return CreationDate(t)
 }
+
+// CreationDateTime returns the `time.Time`'s date formatted in the `02 Jan 2006 • 15:04 UTC` format
+// Example output: 02 Jan 2006 • 15:04 UTC
+func CreationDateTime(t time.Time) string {
+	return t.Format("02 Jan 2006 • 15:04 UTC")
+}

--- a/pkg/humanize/date.go
+++ b/pkg/humanize/date.go
@@ -2,6 +2,7 @@ package humanize
 
 import (
 	"fmt"
+	"log"
 	"time"
 )
 
@@ -29,4 +30,17 @@ func Duration(duration time.Duration) string {
 	seconds = duration / time.Second
 
 	return fmt.Sprintf("%02d:%02d:%02d", hours, minutes, seconds)
+}
+
+// DurationSeconds takes a `time.Duration` and converts it to a string in the following format: %gs where %g is the number of seconds contained within this duration
+// Example output: 53s
+func DurationSeconds(duration time.Duration) string {
+	// Truncate away any non-second data
+	duration = duration.Truncate(1 * time.Second)
+
+	if duration > 90*time.Second {
+		log.Println("WARNING: humanize.DurationSeconds used for duration that's larger than 90 seconds")
+	}
+
+	return fmt.Sprintf("%gs", duration.Seconds())
 }

--- a/pkg/humanize/date.go
+++ b/pkg/humanize/date.go
@@ -3,6 +3,7 @@ package humanize
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 )
 
@@ -21,6 +22,16 @@ func Duration(duration time.Duration) string {
 	seconds = duration / time.Second
 
 	return fmt.Sprintf("%02d:%02d:%02d", hours, minutes, seconds)
+}
+
+// DurationPT takes a PT-formatted string `time.Duration` and converts it to the nearest-second string output using the `Duration` helper
+// Example output: 01:59:59
+// See also: Duration
+func DurationPT(pt string) string {
+	pt = strings.ToLower(pt)
+	pt = strings.Replace(pt, "pt", "", 1)
+	duration, _ := time.ParseDuration(pt)
+	return Duration(duration)
 }
 
 // DurationSeconds takes a `time.Duration` and converts it to a string in the following format: %gs where %g is the number of seconds contained within this duration

--- a/pkg/humanize/date.go
+++ b/pkg/humanize/date.go
@@ -54,6 +54,14 @@ func CreationDateRFC3339(str string) string {
 	return CreationDate(t)
 }
 
+// CreationDateUnix parses the incoming int64 as a unix timestamp and then returns the date in the `CreationDate` format.
+// Example output: 02 Dec 2016
+// See more: `CreationDate`
+func CreationDateUnix(unix int64) string {
+	t := time.Unix(unix, 0)
+	return CreationDate(t)
+}
+
 // CreationDateTime returns the `time.Time`'s date formatted in the `02 Jan 2006 • 15:04 UTC` format
 // Example output: 02 Jan 2006 • 15:04 UTC
 func CreationDateTime(t time.Time) string {

--- a/pkg/humanize/date.go
+++ b/pkg/humanize/date.go
@@ -6,15 +6,6 @@ import (
 	"time"
 )
 
-// Date converts a date from a string in the RFC3339 format into one specified in the format string
-func Date(format string, str string) string {
-	date, err := time.Parse(time.RFC3339, str)
-	if err != nil {
-		return ""
-	}
-	return date.Format(format)
-}
-
 // Duration takes a `time.Duration` and converts it to the nearest-second string output
 // Example output: 01:59:59
 func Duration(duration time.Duration) string {
@@ -49,4 +40,16 @@ func DurationSeconds(duration time.Duration) string {
 // Example output: 02 Dec 2016
 func CreationDate(t time.Time) string {
 	return t.Format("02 Jan 2006")
+}
+
+// CreationDateRFC3339 parses the incoming string as an RFC3339-formatted date and then formats it into the `02 Jan 2006` format
+// If the given string is not a valid RFC3339-formatted date, we will return an empty string
+// Example output: 02 Dec 2016
+// See more: `CreationDate`
+func CreationDateRFC3339(str string) string {
+	t, err := time.Parse(time.RFC3339, str)
+	if err != nil {
+		return ""
+	}
+	return CreationDate(t)
 }

--- a/pkg/humanize/description.go
+++ b/pkg/humanize/description.go
@@ -1,0 +1,19 @@
+package humanize
+
+import "github.com/Chatterino/api/pkg/utils"
+
+// Description formats the input description into a consistent format.
+// Current operations is just limiting the string to 200 characters
+func Description(description string) string {
+	const MaxLength = 200
+
+	return utils.TruncateString(description, MaxLength)
+}
+
+// ShortDescription formats the input description as a short description. Example uses is the `description` key from the Wikipedia page summary API, where the summary for Forsen is "Swedish esports player and Twitch streamer"
+// Current operations is just limiting the string to 60 characters
+func ShortDescription(description string) string {
+	const MaxLength = 60
+
+	return utils.TruncateString(description, MaxLength)
+}

--- a/pkg/humanize/title.go
+++ b/pkg/humanize/title.go
@@ -1,0 +1,11 @@
+package humanize
+
+import "github.com/Chatterino/api/pkg/utils"
+
+// Title formats the input title into a consistent format.
+// Current operations is just limiting the string to 60 characters
+func Title(title string) string {
+	const MaxLength = 60
+
+	return utils.TruncateString(title, MaxLength)
+}

--- a/pkg/utils/url.go
+++ b/pkg/utils/url.go
@@ -41,3 +41,11 @@ func IsSubdomainOf(url *url.URL, parent string) bool {
 
 	return same || trueSub
 }
+
+// IsDomains checks whether `url`s domain matches any of the given domains exactly (non-case sensitive)
+// The `domains` map should only contain fully lowercased domains
+func IsDomains(url *url.URL, domains map[string]struct{}) bool {
+	host := strings.ToLower(url.Host)
+	_, ok := domains[host]
+	return ok
+}

--- a/pkg/utils/url.go
+++ b/pkg/utils/url.go
@@ -53,6 +53,6 @@ func IsDomains(url *url.URL, domains map[string]struct{}) bool {
 // IsDomain checks whether `url`s domain matches the given domain exactly (non-case sensitive)
 // The `domain` string must be fully lowercased
 func IsDomain(url *url.URL, domain string) bool {
-	host := strings.ToLower(url.Host)
+	host := strings.ToLower(url.Hostname())
 	return host == domain
 }

--- a/pkg/utils/url.go
+++ b/pkg/utils/url.go
@@ -49,3 +49,10 @@ func IsDomains(url *url.URL, domains map[string]struct{}) bool {
 	_, ok := domains[host]
 	return ok
 }
+
+// IsDomain checks whether `url`s domain matches the given domain exactly (non-case sensitive)
+// The `domain` string must be fully lowercased
+func IsDomain(url *url.URL, domain string) bool {
+	host := strings.ToLower(url.Host)
+	return host == domain
+}

--- a/pkg/utils/url.go
+++ b/pkg/utils/url.go
@@ -45,7 +45,7 @@ func IsSubdomainOf(url *url.URL, parent string) bool {
 // IsDomains checks whether `url`s domain matches any of the given domains exactly (non-case sensitive)
 // The `domains` map should only contain fully lowercased domains
 func IsDomains(url *url.URL, domains map[string]struct{}) bool {
-	host := strings.ToLower(url.Host)
+	host := strings.ToLower(url.Hostname())
 	_, ok := domains[host]
 	return ok
 }


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->

- [x] internal/resolvers/default/resolver.go MaxTitleLength
- [x] internal/resolvers/default/resolver.go MaxDescriptionLength
- [ ] internal/resolvers/default/thumbnail.go maxThumbnailSize???

- [x] internal/resolvers/discord/load.go date formatting

- [x] internal/resolvers/imgur/check.go could use a better domain checker
- [x] internal/resolvers/imgur/helpers.go formatTimestamp makes a timestamp "created at" string from a unix time (int64)
- [x] internal/resolvers/imgur/resolver.go timestmapFormat

- [x] livestreamfails/load.go CreationData "created at" format
- [x] livestreamfails/resolver.go better domain checking

- [x] supinic/check.go better exact domain-checking
- [x] supinic/load.go better duration formatting?

- [x] twitch/load duration formattiong
- [x] twithc/load creationdate formatting
- [x] twitch/resolver domain checking

- [x] internal/resolvers/twitter/check.go domain checking
- [x] internal/resolvers/twitter/resolver.go timestampFormat should be "humanized"
      CHANGELOG!!!!!!!: twitter timestamp formatting has been changed from "Jan 2 2006" to "02 Jan 2006"

- [x] wiki/resolver max title length/descriptionlength/EXTRACT LENGTH??

- [x] internal/resolvers/youtube/resolver.go domain fixing
- [x] internal/resolvers/youtube/load.go durationParsing from string
- [x] internal/resolvers/youtube/load.go PublishDate/CreationDate

Fixes #82 