### PR TITLE
fix: Updating for new livestreamfails image CDN

### DIFF
--- a/internal/resolvers/livestreamfails/load.go
+++ b/internal/resolvers/livestreamfails/load.go
@@ -2,7 +2,6 @@ package livestreamfails
 
 import (
 	"bytes"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -82,19 +81,7 @@ func load(clipID string, r *http.Request) (interface{}, time.Duration, error) {
 		return &resolverResponse, cache.NoSpecialDur, nil
 	}
 
-	// Make a request for thumbnail
-	thumbnailRequest := LivestreamFailsThumbnailRequest{
-		fmt.Sprintf(thumbnailCDNFormat, clipData.ImageID), // ImageID goes into the hardcoded cloudfront url.
-		Resize{Width: 300, Height: 169},                   // Default values that livestreamfails API uses.
-		Output{Format: "png"},                             // Livestreamfails API uses "webp", but here we use "png".
-	}
-
-	thumbnailRequestJSON, _ := json.Marshal(thumbnailRequest)
-	// Livestreamfails' CDN requests that the url is a base64 encoded JSON string that has the output & resize data.
-	thumbnailRequestJSONToBase64 := base64.StdEncoding.EncodeToString([]byte(thumbnailRequestJSON))
-	thumbnailURL := fmt.Sprintf(thumbnailFormat, thumbnailRequestJSONToBase64)
-
-	resolverResponse.Thumbnail = thumbnailURL
+	resolverResponse.Thumbnail = fmt.Sprintf(thumbnailFormat, clipData.ImageID)
 
 	return &resolverResponse, cache.NoSpecialDur, nil
 }

--- a/internal/resolvers/livestreamfails/resolver.go
+++ b/internal/resolvers/livestreamfails/resolver.go
@@ -17,8 +17,7 @@ import (
 const (
 	livestreamfailsAPIURL = "https://api.livestreamfails.com/clip/%s"
 
-	thumbnailCDNFormat = "https://d2ek7gt5lc50t6.cloudfront.net/image/%s" // Hardcoded(?) cloudfront end-point
-	thumbnailFormat    = "https://alpinecdn.com/v1/%s"
+	thumbnailFormat = "https://livestreamfails-image-prod.b-cdn.net/image/%s"
 
 	livestreamfailsTooltipString = `<div style="text-align: left;">
 {{ if .NSFW }}<li><b><span style="color: red">NSFW</span></b></li>{{ end }}


### PR DESCRIPTION
Pull request checklist:

- [ ] `CHANGELOG.md` was updated, if applicable

# Description
Livestreamfails have changed how they load in thumbnails, they're no longer using AlpineCDN and its weird way of getting images so the logic is simpler too now.