### PR TITLE
Add testing for Wikipedia

### DIFF
--- a/internal/resolvers/wikipedia/helpers.go
+++ b/internal/resolvers/wikipedia/helpers.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"html"
 	"net/http"
 	"net/url"
 	"time"
@@ -57,14 +56,14 @@ func getPageInfo(urlString string) (*wikipediaTooltipData, error) {
 	// Transform API response into our tooltip model for Wikipedia links
 	tooltipData := &wikipediaTooltipData{}
 
-	sanitizedTitle := html.EscapeString(pageInfo.Titles.Display)
+	sanitizedTitle := pageInfo.Titles.Display
 	tooltipData.Title = humanize.Title(sanitizedTitle)
 
-	sanitizedExtract := html.EscapeString(pageInfo.Extract)
+	sanitizedExtract := pageInfo.Extract
 	tooltipData.Extract = humanize.Description(sanitizedExtract)
 
 	if pageInfo.Description != nil {
-		sanitizedDescription := html.EscapeString(*pageInfo.Description)
+		sanitizedDescription := *pageInfo.Description
 		tooltipData.Description = humanize.ShortDescription(sanitizedDescription)
 	}
 

--- a/internal/resolvers/wikipedia/load_test.go
+++ b/internal/resolvers/wikipedia/load_test.go
@@ -13,26 +13,6 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
-func testLoadAndUnescape(c *qt.C, locale, page string) (cleanTooltip string) {
-	urlString := fmt.Sprintf("https://%s.wikipedia.org/wiki/%s", locale, page)
-	iret, _, err := load(urlString, nil)
-
-	c.Assert(err, qt.IsNil)
-	c.Assert(iret, qt.Not(qt.IsNil))
-
-	response := iret.(response)
-
-	c.Assert(response, qt.Not(qt.IsNil))
-	c.Assert(response.err, qt.IsNil)
-
-	c.Assert(response.resolverResponse, qt.Not(qt.IsNil))
-
-	cleanTooltip, unescapeErr := url.PathUnescape(response.resolverResponse.Tooltip)
-	c.Assert(unescapeErr, qt.IsNil)
-
-	return cleanTooltip
-}
-
 var (
 	wikiData = map[string]*wikipediaAPIResponse{}
 )
@@ -64,6 +44,26 @@ func init() {
 		Thumbnail:   nil,
 		Description: nil,
 	}
+}
+
+func testLoadAndUnescape(c *qt.C, locale, page string) (cleanTooltip string) {
+	urlString := fmt.Sprintf("https://%s.wikipedia.org/wiki/%s", locale, page)
+	iret, _, err := load(urlString, nil)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(iret, qt.Not(qt.IsNil))
+
+	response := iret.(response)
+
+	c.Assert(response, qt.Not(qt.IsNil))
+	c.Assert(response.err, qt.IsNil)
+
+	c.Assert(response.resolverResponse, qt.Not(qt.IsNil))
+
+	cleanTooltip, unescapeErr := url.PathUnescape(response.resolverResponse.Tooltip)
+	c.Assert(unescapeErr, qt.IsNil)
+
+	return cleanTooltip
 }
 
 func TestLoad(t *testing.T) {

--- a/internal/resolvers/wikipedia/load_test.go
+++ b/internal/resolvers/wikipedia/load_test.go
@@ -1,0 +1,117 @@
+package wikipedia
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/Chatterino/api/pkg/utils"
+	qt "github.com/frankban/quicktest"
+	"github.com/go-chi/chi/v5"
+)
+
+func testLoadAndUnescape(c *qt.C, locale, page string) (cleanTooltip string) {
+	const urlFormat = "https://%s.wikipedia.org/wiki/%s"
+	urlString := fmt.Sprintf(urlFormat, locale, page)
+	iret, _, err := load(urlString, nil)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(iret, qt.Not(qt.IsNil))
+
+	response := iret.(response)
+
+	c.Assert(response, qt.Not(qt.IsNil))
+	c.Assert(response.err, qt.IsNil)
+
+	c.Assert(response.resolverResponse, qt.Not(qt.IsNil))
+
+	cleanTooltip, unescapeErr := url.PathUnescape(response.resolverResponse.Tooltip)
+	c.Assert(unescapeErr, qt.IsNil)
+
+	return cleanTooltip
+}
+
+var (
+	wikiData = map[string]*wikipediaAPIResponse{}
+)
+
+func init() {
+	wikiData["en_test"] = &wikipediaAPIResponse{
+		Titles: wikipediaAPITitles{
+			Display: "Test title",
+		},
+		Extract:     "Test extract",
+		Thumbnail:   nil,
+		Description: utils.StringPtr("Test description"),
+	}
+
+	wikiData["en_test_html"] = &wikipediaAPIResponse{
+		Titles: wikipediaAPITitles{
+			Display: "<b>Test title</b>",
+		},
+		Extract:     "<b>Test extract</b>",
+		Thumbnail:   nil,
+		Description: utils.StringPtr("<b>Test description</b>"),
+	}
+}
+
+func TestLoad(t *testing.T) {
+	c := qt.New(t)
+	r := chi.NewRouter()
+	r.Get("/api/rest_v1/page/summary/{locale}/{page}", func(w http.ResponseWriter, r *http.Request) {
+		locale := chi.URLParam(r, "locale")
+		page := chi.URLParam(r, "page")
+
+		var response *wikipediaAPIResponse
+		var ok bool
+
+		if response, ok = wikiData[locale+"_"+page]; !ok {
+			http.Error(w, http.StatusText(404), 404)
+			return
+		}
+
+		b, _ := json.Marshal(&response)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(b)
+	})
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+	endpointURL = ts.URL + "/api/rest_v1/page/summary/%s/%s"
+
+	c.Run("Normal page", func(c *qt.C) {
+		const locale = "en"
+		const page = "test"
+
+		const expectedTooltip = `<div style="text-align: left;"><b>Test title&nbsp;•&nbsp;Test description</b><br>Test extract</div>`
+
+		cleanTooltip := testLoadAndUnescape(c, locale, page)
+
+		c.Assert(cleanTooltip, qt.Equals, expectedTooltip)
+	})
+
+	c.Run("Normal page (HTML)", func(c *qt.C) {
+		const locale = "en"
+		const page = "test_html"
+
+		const expectedTooltip = `<div style="text-align: left;"><b>&lt;b&gt;Test title&lt;/b&gt;&nbsp;•&nbsp;&lt;b&gt;Test description&lt;/b&gt;</b><br>&lt;b&gt;Test extract&lt;/b&gt;</div>`
+
+		cleanTooltip := testLoadAndUnescape(c, locale, page)
+
+		c.Assert(cleanTooltip, qt.Equals, expectedTooltip)
+	})
+
+	// c.Run("Nonexistant page", func(c *qt.C) {
+	// 	const locale = "en"
+	// 	const page = "404"
+
+	// 	const expectedTooltip = `404`
+
+	// 	cleanTooltip := testLoadAndUnescape(c, locale, page)
+
+	// 	c.Assert(cleanTooltip, qt.Equals, expectedTooltip)
+	// })
+}

--- a/internal/resolvers/wikipedia/load_test.go
+++ b/internal/resolvers/wikipedia/load_test.go
@@ -56,6 +56,15 @@ func init() {
 		Thumbnail:   nil,
 		Description: utils.StringPtr("<b>Test description</b>"),
 	}
+
+	wikiData["en_test_no_description"] = &wikipediaAPIResponse{
+		Titles: wikipediaAPITitles{
+			Display: "Test title",
+		},
+		Extract:     "Test extract",
+		Thumbnail:   nil,
+		Description: nil,
+	}
 }
 
 func TestLoad(t *testing.T) {
@@ -98,6 +107,17 @@ func TestLoad(t *testing.T) {
 		const page = "test_html"
 
 		const expectedTooltip = `<div style="text-align: left;"><b>&lt;b&gt;Test title&lt;/b&gt;&nbsp;•&nbsp;&lt;b&gt;Test description&lt;/b&gt;</b><br>&lt;b&gt;Test extract&lt;/b&gt;</div>`
+
+		cleanTooltip := testLoadAndUnescape(c, locale, page)
+
+		c.Assert(cleanTooltip, qt.Equals, expectedTooltip)
+	})
+
+	c.Run("Normal page (No description)", func(c *qt.C) {
+		const locale = "en"
+		const page = "test_no_description"
+
+		const expectedTooltip = `<div style="text-align: left;"><b>Test title</b><br>Test extract</div>`
 
 		cleanTooltip := testLoadAndUnescape(c, locale, page)
 

--- a/internal/resolvers/wikipedia/load_test.go
+++ b/internal/resolvers/wikipedia/load_test.go
@@ -14,8 +14,7 @@ import (
 )
 
 func testLoadAndUnescape(c *qt.C, locale, page string) (cleanTooltip string) {
-	const urlFormat = "https://%s.wikipedia.org/wiki/%s"
-	urlString := fmt.Sprintf(urlFormat, locale, page)
+	urlString := fmt.Sprintf("https://%s.wikipedia.org/wiki/%s", locale, page)
 	iret, _, err := load(urlString, nil)
 
 	c.Assert(err, qt.IsNil)

--- a/internal/resolvers/wikipedia/model.go
+++ b/internal/resolvers/wikipedia/model.go
@@ -21,8 +21,7 @@ type wikipediaTooltipData struct {
 	ThumbnailURL string
 }
 
-const wikipediaTooltip = `<div style="text-align: left;">
-<b>{{.Title}}{{ if .Description }}&nbsp;•&nbsp;{{.Description}}{{ end }}</b><br>
-{{.Extract}}
-</div>
-`
+const wikipediaTooltip = `<div style="text-align: left;">` +
+	`<b>{{.Title}}{{ if .Description }}&nbsp;•&nbsp;{{.Description}}{{ end }}</b><br>` +
+	`{{.Extract}}` +
+	`</div>`

--- a/internal/resolvers/wikipedia/model.go
+++ b/internal/resolvers/wikipedia/model.go
@@ -1,17 +1,21 @@
 package wikipedia
 
+type wikipediaAPITitles struct {
+	Display string `json:"display"`
+}
+
+type wikipediaAPIThumbnail struct {
+	URL string `json:"source"`
+}
+
 // The `Thumbnail` and `Description` fields are declared as pointers because
 // they are not strictly required by the schema and may be omitted for some
 // pages. In these cases, the fields will be nil.
 type wikipediaAPIResponse struct {
-	Titles struct {
-		Display string `json:"display"`
-	} `json:"titles"`
-	Extract   string `json:"extract"`
-	Thumbnail *struct {
-		URL string `json:"source"`
-	} `json:"thumbnail"`
-	Description *string `json:"description"`
+	Titles      wikipediaAPITitles     `json:"titles"`
+	Extract     string                 `json:"extract"`
+	Thumbnail   *wikipediaAPIThumbnail `json:"thumbnail"`
+	Description *string                `json:"description"`
 }
 
 type wikipediaTooltipData struct {

--- a/internal/resolvers/wikipedia/resolver.go
+++ b/internal/resolvers/wikipedia/resolver.go
@@ -2,8 +2,8 @@ package wikipedia
 
 import (
 	"errors"
+	"html/template"
 	"regexp"
-	"text/template"
 	"time"
 
 	"github.com/Chatterino/api/pkg/cache"

--- a/internal/resolvers/wikipedia/resolver.go
+++ b/internal/resolvers/wikipedia/resolver.go
@@ -20,9 +20,7 @@ var (
 
 	errLocaleMatch = errors.New("could not find locale from URL")
 	errTitleMatch  = errors.New("could not find title from URL")
-)
 
-const (
 	endpointURL = "https://%s.wikipedia.org/api/rest_v1/page/summary/%s?redirect=false"
 )
 

--- a/pkg/utils/string.go
+++ b/pkg/utils/string.go
@@ -11,3 +11,7 @@ func TruncateString(s string, maxLength int) string {
 
 	return strings.TrimSpace(string(runes[:maxLength-1])) + "…"
 }
+
+func StringPtr(s string) *string {
+	return &s
+}


### PR DESCRIPTION
- make endpointURL modifiable so we can test it easier
- make wikipedia tooltip into a single line to simplify testing
- remove use of anonymous structs in wikipedia api response to make it easier to mock
- Add StringPtr helper function for creating a string pointer
- Add very basic testing for Wikipedia

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
