### PR TITLE
Add HTML escaping and testing to the BetterTTV resolver

### DIFF
--- a/internal/resolvers/betterttv/load_test.go
+++ b/internal/resolvers/betterttv/load_test.go
@@ -1,0 +1,140 @@
+package betterttv
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/Chatterino/api/pkg/resolver"
+	qt "github.com/frankban/quicktest"
+	"github.com/go-chi/chi/v5"
+)
+
+var (
+	data = map[string]*EmoteAPIResponse{}
+)
+
+func init() {
+	data["kkona"] = &EmoteAPIResponse{
+		Code: "KKona",
+		User: EmoteAPIUser{
+			DisplayName: "zneix",
+		},
+		Global: true,
+	}
+
+	data["kkona_html"] = &EmoteAPIResponse{
+		Code: "<b>KKona</b>",
+		User: EmoteAPIUser{
+			DisplayName: "<b>zneix</b>",
+		},
+		Global: true,
+	}
+
+	data["forsenga"] = &EmoteAPIResponse{
+		Code: "forsenGa",
+		User: EmoteAPIUser{
+			DisplayName: "pajlada",
+		},
+	}
+
+	data["forsenga_html"] = &EmoteAPIResponse{
+		Code: "<b>forsenGa</b>",
+		User: EmoteAPIUser{
+			DisplayName: "<b>pajlada</b>",
+		},
+	}
+}
+
+func testLoadAndUnescape(c *qt.C, emote string) (cleanTooltip string) {
+	iret, _, err := load(emote, nil)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(iret, qt.Not(qt.IsNil))
+
+	response := iret.(*resolver.Response)
+
+	c.Assert(response, qt.Not(qt.IsNil))
+
+	cleanTooltip, unescapeErr := url.PathUnescape(response.Tooltip)
+	c.Assert(unescapeErr, qt.IsNil)
+
+	return cleanTooltip
+}
+
+func TestLoad(t *testing.T) {
+	c := qt.New(t)
+	r := chi.NewRouter()
+	r.Get("/3/emotes/{emote}", func(w http.ResponseWriter, r *http.Request) {
+		emote := chi.URLParam(r, "emote")
+
+		var response *EmoteAPIResponse
+		var ok bool
+
+		w.Header().Set("Content-Type", "application/json")
+
+		if response, ok = data[emote]; !ok {
+			http.Error(w, http.StatusText(404), 404)
+			return
+		}
+
+		b, _ := json.Marshal(&response)
+
+		w.Write(b)
+	})
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+	emoteAPIURL = ts.URL + "/3/emotes/%s"
+
+	c.Run("Global emote", func(c *qt.C) {
+		const emote = "kkona"
+
+		const expectedTooltip = `<div style="text-align: left;"><b>KKona</b><br><b>Global BetterTTV Emote</b><br><b>By:</b> zneix</div>`
+
+		cleanTooltip := testLoadAndUnescape(c, emote)
+
+		c.Assert(cleanTooltip, qt.Equals, expectedTooltip)
+	})
+
+	c.Run("Global emote (HTML)", func(c *qt.C) {
+		const emote = "kkona_html"
+
+		const expectedTooltip = `<div style="text-align: left;"><b>&lt;b&gt;KKona&lt;/b&gt;</b><br><b>Global BetterTTV Emote</b><br><b>By:</b> &lt;b&gt;zneix&lt;/b&gt;</div>`
+
+		cleanTooltip := testLoadAndUnescape(c, emote)
+
+		c.Assert(cleanTooltip, qt.Equals, expectedTooltip)
+	})
+
+	c.Run("Shared emote", func(c *qt.C) {
+		const emote = "forsenga"
+
+		const expectedTooltip = `<div style="text-align: left;"><b>forsenGa</b><br><b>Shared BetterTTV Emote</b><br><b>By:</b> pajlada</div>`
+
+		cleanTooltip := testLoadAndUnescape(c, emote)
+
+		c.Assert(cleanTooltip, qt.Equals, expectedTooltip)
+	})
+
+	c.Run("Shared emote (HTML)", func(c *qt.C) {
+		const emote = "forsenga_html"
+
+		const expectedTooltip = `<div style="text-align: left;"><b>&lt;b&gt;forsenGa&lt;/b&gt;</b><br><b>Shared BetterTTV Emote</b><br><b>By:</b> &lt;b&gt;pajlada&lt;/b&gt;</div>`
+
+		cleanTooltip := testLoadAndUnescape(c, emote)
+
+		c.Assert(cleanTooltip, qt.Equals, expectedTooltip)
+	})
+
+	// c.Run("404 emote", func(c *qt.C) {
+	// 	const emote = "404"
+
+	// 	const expectedTooltip = `<div style="text-align: left;"><b>forsenGa</b><br><b>Shared BetterTTV Emote</b><br><b>By:</b> pajlada</div>`
+
+	// 	cleanTooltip := testLoadAndUnescape(c, emote)
+
+	// 	c.Assert(cleanTooltip, qt.Equals, expectedTooltip)
+	// })
+}

--- a/internal/resolvers/betterttv/model.go
+++ b/internal/resolvers/betterttv/model.go
@@ -2,22 +2,24 @@ package betterttv
 
 import "time"
 
+type EmoteAPIUser struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	DisplayName string `json:"displayName"`
+	ProviderID  string `json:"providerId"`
+}
+
 type EmoteAPIResponse struct {
-	ID             string    `json:"id"`
-	Code           string    `json:"code"`
-	ImageType      string    `json:"imageType"`
-	CreatedAt      time.Time `json:"createdAt"`
-	UpdatedAt      time.Time `json:"updatedAt"`
-	Global         bool      `json:"global"`
-	Live           bool      `json:"live"`
-	Sharing        bool      `json:"sharing"`
-	ApprovalStatus string    `json:"approvalStatus"`
-	User           struct {
-		ID          string `json:"id"`
-		Name        string `json:"name"`
-		DisplayName string `json:"displayName"`
-		ProviderID  string `json:"providerId"`
-	} `json:"user"`
+	ID             string       `json:"id"`
+	Code           string       `json:"code"`
+	ImageType      string       `json:"imageType"`
+	CreatedAt      time.Time    `json:"createdAt"`
+	UpdatedAt      time.Time    `json:"updatedAt"`
+	Global         bool         `json:"global"`
+	Live           bool         `json:"live"`
+	Sharing        bool         `json:"sharing"`
+	ApprovalStatus string       `json:"approvalStatus"`
+	User           EmoteAPIUser `json:"user"`
 }
 
 type TooltipData struct {

--- a/internal/resolvers/betterttv/resolver.go
+++ b/internal/resolvers/betterttv/resolver.go
@@ -13,10 +13,11 @@ import (
 const (
 	thumbnailFormat = "https://cdn.betterttv.net/emote/%s/3x"
 
-	tooltipTemplate = `<div style="text-align: left;">
-<b>{{.Code}}</b><br>
-<b>{{.Type}} BetterTTV Emote</b><br>
-<b>By:</b> {{.Uploader}}</div>`
+	tooltipTemplate = `<div style="text-align: left;">` +
+		`<b>{{.Code}}</b><br>` +
+		`<b>{{.Type}} BetterTTV Emote</b><br>` +
+		`<b>By:</b> {{.Uploader}}` +
+		`</div>`
 )
 
 var (

--- a/internal/resolvers/betterttv/resolver.go
+++ b/internal/resolvers/betterttv/resolver.go
@@ -11,8 +11,6 @@ import (
 )
 
 const (
-	emoteAPIURL = "https://api.betterttv.net/3/emotes/%s"
-
 	thumbnailFormat = "https://cdn.betterttv.net/emote/%s/3x"
 
 	tooltipTemplate = `<div style="text-align: left;">
@@ -22,6 +20,8 @@ const (
 )
 
 var (
+	emoteAPIURL = "https://api.betterttv.net/3/emotes/%s"
+
 	errInvalidBTTVEmotePath = errors.New("invalid BetterTTV emote path")
 
 	// BetterTTV hosts we're doing our smart things on

--- a/internal/resolvers/betterttv/resolver.go
+++ b/internal/resolvers/betterttv/resolver.go
@@ -2,8 +2,8 @@ package betterttv
 
 import (
 	"errors"
+	"html/template"
 	"regexp"
-	"text/template"
 	"time"
 
 	"github.com/Chatterino/api/pkg/cache"


### PR DESCRIPTION
- Get rid of anonymous struct in model so we can more easily mock the API response
- Make emoteAPIURL non-const so we can modify it for tests
- Make the tooltip response single line for easier testing
- Add simple tests
- Switch from `text/template` to `html/template`

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
