### PR TITLE
feat: Support for animated GIF & static WebP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Non-Windows builds now use `discord/lilliput` to support animated GIFs and static WebP thumbnails. (#119)
 - Twitter resolver timestamp date format changed from `Jan 2 2006` to `02 Jan 2006` (#105)
 - Dev, Breaking: Moved main package from root directory to `/cmd/api`. This change also changes the path of the executable from `./api` to `./cmd/api/api` - make sure to reflect this change in your systemd unit. (#104, #107)
 - Dev: Replaced `gorilla/mux` with `go-chi/chi`. This change requires the URL parameters to be percent-encoded, specifically the slashes. (#99)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.15
 require (
 	github.com/PuerkitoBio/goquery v1.6.1
 	github.com/dankeroni/gotwitch v0.0.0-20190429150511-5924c422419a
+	github.com/discord/lilliput v0.0.0-20210410064651-6e127f25858d
 	github.com/frankban/quicktest v1.11.3
 	github.com/go-chi/chi/v5 v5.0.2
 	github.com/golang/mock v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,8 @@ github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnht
 github.com/dankeroni/gotwitch v0.0.0-20190429150511-5924c422419a h1:Y9MLN64hkshOJeudF4UwBQX9kjBlvjBeH3ru59Y2FZs=
 github.com/dankeroni/gotwitch v0.0.0-20190429150511-5924c422419a/go.mod h1:lWs5CtxMaI7rSsvehIPXHnuZ3h5ojuCjWtMrYme8sKk=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/discord/lilliput v0.0.0-20210410064651-6e127f25858d h1:jWQgeT6mu5HOHTYkG38bK3gEmCDPTl93mtXmFeSvFmY=
+github.com/discord/lilliput v0.0.0-20210410064651-6e127f25858d/go.mod h1:0euuUBAD72MAYRm2ElLaG1h0nBR+CgpfnKc/U6y/uE8=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/internal/resolvers/default/thumbnail.go
+++ b/internal/resolvers/default/thumbnail.go
@@ -2,12 +2,7 @@
 package defaultresolver
 
 import (
-	"bytes"
 	"fmt"
-	"image"
-	"image/gif"
-	"image/jpeg"
-	"image/png"
 	"log"
 	"net/http"
 	"net/url"
@@ -19,11 +14,10 @@ import (
 	"github.com/Chatterino/api/pkg/resolver"
 	"github.com/Chatterino/api/pkg/utils"
 	"github.com/go-chi/chi/v5"
-	"github.com/nfnt/resize"
 )
 
 var (
-	supportedThumbnails = []string{"image/jpeg", "image/png", "image/gif"}
+	supportedThumbnails = []string{"image/jpeg", "image/png", "image/gif", "image/webp"}
 )
 
 const (
@@ -113,26 +107,4 @@ var (
 
 func InitializeThumbnail(router *chi.Mux) {
 	router.Get("/thumbnail/{url}", thumbnail)
-}
-
-func buildThumbnailByteArray(resp *http.Response) ([]byte, error) {
-	image, _, err := image.Decode(resp.Body)
-	if err != nil {
-		return []byte{}, fmt.Errorf("could not decode image from url: %s", resp.Request.URL)
-	}
-
-	resized := resize.Thumbnail(maxThumbnailSize, maxThumbnailSize, image, resize.Bilinear)
-	buffer := new(bytes.Buffer)
-	if resp.Header.Get("content-type") == "image/png" {
-		err = png.Encode(buffer, resized)
-	} else if resp.Header.Get("content-type") == "image/gif" {
-		err = gif.Encode(buffer, resized, nil)
-	} else if resp.Header.Get("content-type") == "image/jpeg" {
-		err = jpeg.Encode(buffer, resized, nil)
-	}
-	if err != nil {
-		return []byte{}, fmt.Errorf("could not encode image from url: %s", resp.Request.URL)
-	}
-
-	return buffer.Bytes(), nil
 }

--- a/internal/resolvers/default/thumbnail.go
+++ b/internal/resolvers/default/thumbnail.go
@@ -2,7 +2,13 @@
 package defaultresolver
 
 import (
+	"bytes"
 	"fmt"
+	"image"
+	"image/gif"
+	"image/jpeg"
+	"image/png"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -14,6 +20,7 @@ import (
 	"github.com/Chatterino/api/pkg/resolver"
 	"github.com/Chatterino/api/pkg/utils"
 	"github.com/go-chi/chi/v5"
+	"github.com/nfnt/resize"
 )
 
 var (
@@ -24,6 +31,29 @@ const (
 	// max width or height the thumbnail will be resized to
 	maxThumbnailSize = 300
 )
+
+// buildStaticThumbnailByteArray is used when we fail to build an animated thumbnail using lilliput
+func buildStaticThumbnailByteArray(inputBuf []byte, resp *http.Response) ([]byte, error) {
+	image, _, err := image.Decode(bytes.NewReader(inputBuf))
+	if err != nil {
+		return []byte{}, fmt.Errorf("could not decode image from url: %s", resp.Request.URL)
+	}
+
+	resized := resize.Thumbnail(maxThumbnailSize, maxThumbnailSize, image, resize.Bilinear)
+	buffer := new(bytes.Buffer)
+	if resp.Header.Get("content-type") == "image/png" {
+		err = png.Encode(buffer, resized)
+	} else if resp.Header.Get("content-type") == "image/gif" {
+		err = gif.Encode(buffer, resized, nil)
+	} else if resp.Header.Get("content-type") == "image/jpeg" {
+		err = jpeg.Encode(buffer, resized, nil)
+	}
+	if err != nil {
+		return []byte{}, fmt.Errorf("could not encode image from url: %s", resp.Request.URL)
+	}
+
+	return buffer.Bytes(), nil
+}
 
 func doThumbnailRequest(urlString string, r *http.Request) (interface{}, time.Duration, error) {
 	url, err := url.Parse(urlString)
@@ -64,10 +94,20 @@ func doThumbnailRequest(urlString string, r *http.Request) (interface{}, time.Du
 		return resolver.NoLinkInfoFound, cache.NoSpecialDur, nil
 	}
 
-	image, err := buildThumbnailByteArray(resp)
+	inputBuf, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		log.Println(err.Error())
+		log.Println("Error reading body from request:", err)
 		return resolver.NoLinkInfoFound, cache.NoSpecialDur, nil
+	}
+
+	image, err := buildThumbnailByteArray(inputBuf, resp)
+	if err != nil {
+		log.Println("Error trying to build animated thumbnail:", err.Error(), "falling back to static thumbnail building")
+		image, err = buildStaticThumbnailByteArray(inputBuf, resp)
+		if err != nil {
+			log.Println("Error trying to build static thumbnail:", err.Error())
+			return resolver.NoLinkInfoFound, cache.NoSpecialDur, nil
+		}
 	}
 
 	return image, 10 * time.Minute, nil

--- a/internal/resolvers/default/thumbnail_unix.go
+++ b/internal/resolvers/default/thumbnail_unix.go
@@ -1,0 +1,99 @@
+// +build !windows
+
+package defaultresolver
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/discord/lilliput"
+)
+
+var (
+	EncodeOptions = map[string]map[int]int{
+		".jpeg": {lilliput.JpegQuality: 85},
+		".png":  {lilliput.PngCompression: 7},
+		".webp": {lilliput.WebpQuality: 85},
+	}
+)
+
+func buildThumbnailByteArray(resp *http.Response) ([]byte, error) {
+	// decoder wants []byte, so read the whole file into a buffer
+	inputBuf, _ := ioutil.ReadAll(resp.Body)
+
+	decoder, err := lilliput.NewDecoder(inputBuf)
+	// this error reflects very basic checks,
+	// mostly just for the magic bytes of the file to match known image formats
+	if err != nil {
+		return []byte{}, fmt.Errorf("could not decode image from url: %s", resp.Request.URL)
+	}
+	defer decoder.Close()
+
+	header, err := decoder.Header()
+	// this error is much more comprehensive and reflects
+	// format errors
+	if err != nil {
+		return []byte{}, fmt.Errorf("could not read image header from url: %s", resp.Request.URL)
+	}
+
+	newWidth := header.Width()
+	newHeight := header.Height()
+
+	// get ready to resize image,
+	// using 8192x8192 maximum resize buffer size
+	ops := lilliput.NewImageOps(8192)
+	defer ops.Close()
+
+	// create a buffer to store the output image, 50MB in this case
+	outputImg := make([]byte, 50*1024*1024)
+
+	// don't transcode (use existing type)
+	outputType := "." + strings.ToLower(decoder.Description())
+
+	// We want to default to no resizing.
+	resizeMethod := lilliput.ImageOpsNoResize
+
+	// Only trigger if original image has higher values than maxThumbnailSize
+	if maxThumbnailSize < newWidth && maxThumbnailSize < newHeight {
+		resizeMethod = lilliput.ImageOpsResize // We want to resize
+
+		/* Preserve aspect ratio is from previous module, thanks nfnt/resize.
+		 * (https://github.com/nfnt/resize/blob/83c6a9932646f83e3267f353373d47347b6036b2/thumbnail.go#L27)
+		 */
+
+		// Preserve aspect ratio
+		if newWidth > maxThumbnailSize {
+			newHeight = newHeight * maxThumbnailSize / newWidth
+			if newHeight < 1 {
+				newHeight = 1
+			}
+			newWidth = maxThumbnailSize
+		}
+
+		if newHeight > maxThumbnailSize {
+			newWidth = newWidth * maxThumbnailSize / newHeight
+			if newWidth < 1 {
+				newWidth = 1
+			}
+			newHeight = maxThumbnailSize
+		}
+	}
+
+	opts := &lilliput.ImageOptions{
+		FileType:      outputType,
+		Width:         newWidth,
+		Height:        newHeight,
+		ResizeMethod:  resizeMethod,
+		EncodeOptions: EncodeOptions[outputType],
+	}
+
+	// resize and transcode image
+	outputImg, err = ops.Transform(decoder, opts, outputImg)
+	if err != nil {
+		return []byte{}, fmt.Errorf("could not transform image from url: %s", resp.Request.URL)
+	}
+
+	return outputImg, nil
+}

--- a/internal/resolvers/default/thumbnail_unix.go
+++ b/internal/resolvers/default/thumbnail_unix.go
@@ -4,7 +4,6 @@ package defaultresolver
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -19,10 +18,8 @@ var (
 	}
 )
 
-func buildThumbnailByteArray(resp *http.Response) ([]byte, error) {
+func buildThumbnailByteArray(inputBuf []byte, resp *http.Response) ([]byte, error) {
 	// decoder wants []byte, so read the whole file into a buffer
-	inputBuf, _ := ioutil.ReadAll(resp.Body)
-
 	decoder, err := lilliput.NewDecoder(inputBuf)
 	// this error reflects very basic checks,
 	// mostly just for the magic bytes of the file to match known image formats
@@ -42,12 +39,12 @@ func buildThumbnailByteArray(resp *http.Response) ([]byte, error) {
 	newHeight := header.Height()
 
 	// get ready to resize image,
-	// using 8192x8192 maximum resize buffer size
 	ops := lilliput.NewImageOps(8192)
 	defer ops.Close()
 
-	// create a buffer to store the output image, 50MB in this case
-	outputImg := make([]byte, 50*1024*1024)
+	// create a buffer to store the output image, 2MB in this case
+	// If the final image does not fit within this buffer, then we fall back to providing a static thumbnail
+	outputImg := make([]byte, 2*1024*1024)
 
 	// don't transcode (use existing type)
 	outputType := "." + strings.ToLower(decoder.Description())

--- a/internal/resolvers/default/thumbnail_windows.go
+++ b/internal/resolvers/default/thumbnail_windows.go
@@ -8,5 +8,5 @@ import (
 
 func buildThumbnailByteArray(inputBuf []byte, resp *http.Response) ([]byte, error) {
 	// Since the lilliput library currently does not support Windows, we error out early and fall back to the static thumbnail generation
-	return nil, errors.New("cannot build thumbnail")
+	return nil, errors.New("Cannot build animated thumbnails on Windows")
 }

--- a/internal/resolvers/default/thumbnail_windows.go
+++ b/internal/resolvers/default/thumbnail_windows.go
@@ -3,35 +3,10 @@
 package defaultresolver
 
 import (
-	"bytes"
-	"fmt"
-	"image"
-	"image/gif"
-	"image/jpeg"
-	"image/png"
 	"net/http"
-
-	"github.com/nfnt/resize"
 )
 
-func buildThumbnailByteArray(resp *http.Response) ([]byte, error) {
-	image, _, err := image.Decode(resp.Body)
-	if err != nil {
-		return []byte{}, fmt.Errorf("could not decode image from url: %s", resp.Request.URL)
-	}
-
-	resized := resize.Thumbnail(maxThumbnailSize, maxThumbnailSize, image, resize.Bilinear)
-	buffer := new(bytes.Buffer)
-	if resp.Header.Get("content-type") == "image/png" {
-		err = png.Encode(buffer, resized)
-	} else if resp.Header.Get("content-type") == "image/gif" {
-		err = gif.Encode(buffer, resized, nil)
-	} else if resp.Header.Get("content-type") == "image/jpeg" {
-		err = jpeg.Encode(buffer, resized, nil)
-	}
-	if err != nil {
-		return []byte{}, fmt.Errorf("could not encode image from url: %s", resp.Request.URL)
-	}
-
-	return buffer.Bytes(), nil
+func buildThumbnailByteArray(inputBuf []byte, resp *http.Response) ([]byte, error) {
+	// Since the lilliput library currently does not support Windows, we error out early and fall back to the static thumbnail generation
+	return nil, errors.New("cannot build thumbnail")
 }

--- a/internal/resolvers/default/thumbnail_windows.go
+++ b/internal/resolvers/default/thumbnail_windows.go
@@ -3,10 +3,11 @@
 package defaultresolver
 
 import (
+	"errors"
 	"net/http"
 )
 
 func buildThumbnailByteArray(inputBuf []byte, resp *http.Response) ([]byte, error) {
 	// Since the lilliput library currently does not support Windows, we error out early and fall back to the static thumbnail generation
-	return nil, errors.New("Cannot build animated thumbnails on Windows")
+	return nil, errors.New("cannot build animated thumbnails on windows")
 }

--- a/internal/resolvers/default/thumbnail_windows.go
+++ b/internal/resolvers/default/thumbnail_windows.go
@@ -1,0 +1,37 @@
+// +build windows
+
+package defaultresolver
+
+import (
+	"bytes"
+	"fmt"
+	"image"
+	"image/gif"
+	"image/jpeg"
+	"image/png"
+	"net/http"
+
+	"github.com/nfnt/resize"
+)
+
+func buildThumbnailByteArray(resp *http.Response) ([]byte, error) {
+	image, _, err := image.Decode(resp.Body)
+	if err != nil {
+		return []byte{}, fmt.Errorf("could not decode image from url: %s", resp.Request.URL)
+	}
+
+	resized := resize.Thumbnail(maxThumbnailSize, maxThumbnailSize, image, resize.Bilinear)
+	buffer := new(bytes.Buffer)
+	if resp.Header.Get("content-type") == "image/png" {
+		err = png.Encode(buffer, resized)
+	} else if resp.Header.Get("content-type") == "image/gif" {
+		err = gif.Encode(buffer, resized, nil)
+	} else if resp.Header.Get("content-type") == "image/jpeg" {
+		err = jpeg.Encode(buffer, resized, nil)
+	}
+	if err != nil {
+		return []byte{}, fmt.Errorf("could not encode image from url: %s", resp.Request.URL)
+	}
+
+	return buffer.Bytes(), nil
+}


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Allows Chatterino-API to send animated GIFs and static WEBP images, by using Discord's "lilliput" CGO library, to the api consumers (aka Chatterino2).

Since lilliput only works for OSX & Linux, I've used build constraints on the top of the files as well as in the names of the files (yay, redundancy) so that windows builds the previous way of displaying image previews via the nfnt/resize module instead.

The implementation is based on lilliput's example code, and the aspect ratio resize code is based on nfnt/resize code.

Here's a video showcase:
https://streamable.com/882frr 

<details>
  <summary>Here's some test links</summary>

https://i.nuuls.com/vV-4B.png?xd
https://i.nuuls.com/pwhf_.png?xd
https://i.nuuls.com/O3uGY.gif?xd

https://upload.wikimedia.org/wikipedia/commons/4/47/PNG_transparency_demonstration_1.png?xd
https://upload.wikimedia.org/wikipedia/commons/a/a1/Johnrogershousemay2020.webp?xd
https://upload.wikimedia.org/wikipedia/commons/2/2c/Rotating_earth_%28large%29.gif?xd
https://res.cloudinary.com/demo/image/upload/fl_awebp/bored_animation.webp?this_image_is_not_supposed_to_work
https://mathiasbynens.be/demo/animated-webp-supported.webp?this_image_is_not_supposed_to_work

https://cdn.betterttv.net/emote/5e10fd8c3267f72103fd4f25/1x?xd
https://cdn.betterttv.net/emote/5f8c050d40eb9502e2225b4c/3x?xd

https://zneix.eu/
</details>

While WebP is supported, animated WebP is not supported and it will instead show nothing at all. Since lilliput is being used by Discord too, and Discord is showcasing the same behavior (https://i.nuuls.com/k27Vh.png) I'm going to make the claim that nobody is currently taking animated WebP seriously and so whatever eShrug xd

## Curiosities / Help wanted

**https://github.com/KararTY/api/blob/support-gif-webp/internal/resolvers/default/thumbnail_unix.go#L44**
I am not entirely certain by what this means and whether we could reduce this number or not. The relevant lilliput code for this is over [here](https://github.com/discord/lilliput/blob/master/ops.go#L54).

https://github.com/KararTY/api/blob/support-gif-webp/internal/resolvers/default/thumbnail_unix.go#L50
The example code defaults a buffer for the output image to 50MB, which is what I left it at, but since chatterino-api don't load in links over 5MB can this be reduced?

And lastly: I am not completely familiar with how Go deals with memory, so I haven't checked memory consumption and/or if there's a potential memory leak so this is a request for help, and a consideration for anyone who wants to review this code.

oh and if you have read this far, VI VON ZULUL 