### PR TITLE
fix: MQ instead of SD for rectangular thumbnails.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Youtube thumbnails are now in medium quality instead of standard definition to get a rectangular shaped image. (#127)
+
 ## 1.0.1
 
 - Dev: You can now set the Base URL flag with the `CHATTERINO_API_BASE_URL` environment variable. (#123)

--- a/internal/resolvers/youtube/load.go
+++ b/internal/resolvers/youtube/load.go
@@ -58,8 +58,8 @@ func load(videoID string, r *http.Request) (interface{}, time.Duration, error) {
 	}
 
 	thumbnail := video.Snippet.Thumbnails.Default.Url
-	if video.Snippet.Thumbnails.Standard != nil {
-		thumbnail = video.Snippet.Thumbnails.Standard.Url
+	if video.Snippet.Thumbnails.Medium != nil {
+		thumbnail = video.Snippet.Thumbnails.Medium.Url
 	}
 
 	return &resolver.Response{


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Note: **I've not tested this fix, because my daily YouTube quota is set to 0 for some reason.**

Standard Definition (SD) thumbnails have black bars on the top and bottom.
![image](https://user-images.githubusercontent.com/13697809/115392608-0c3d7580-a1e1-11eb-851f-d3b879310f9f.png)

You can see this here for SD: https://i.ytimg.com/vi/JZe5QV5wcY0/sddefault.jpg

This fix should give Medium Quality (MQ) thumbnails instead: https://i.ytimg.com/vi/JZe5QV5wcY0/mqdefault.jpg