### PR TITLE
fix: Original quality Twitter profile pictures.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Twitter profile pictures are now returned in their original quality. (#131)
+
 ## 1.0.1
 
 - Dev: You can now set the Base URL flag with the `CHATTERINO_API_BASE_URL` environment variable. (#123)

--- a/internal/resolvers/twitter/api.go
+++ b/internal/resolvers/twitter/api.go
@@ -60,7 +60,7 @@ func buildTwitterUserTooltip(user *TwitterUserApiResponse) *twitterUserTooltipDa
 	data.Username = user.Username
 	data.Description = user.Description
 	data.Followers = humanize.Number(user.Followers)
-	data.Thumbnail = strings.Replace(user.ProfileImageUrl, "_normal", "", 1)
+	data.Thumbnail = user.ProfileImageUrl
 
 	return data
 }
@@ -111,6 +111,9 @@ func getUserByName(userName, bearer string) (*TwitterUserApiResponse, error) {
 	if err != nil {
 		return nil, errors.New("unable to process response")
 	}
+
+	// Do modifications to response
+	user.ProfileImageUrl = strings.Replace(user.ProfileImageUrl, "_normal", "", 1)
 
 	return user, nil
 }

--- a/internal/resolvers/twitter/api.go
+++ b/internal/resolvers/twitter/api.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/Chatterino/api/pkg/humanize"
@@ -59,7 +60,7 @@ func buildTwitterUserTooltip(user *TwitterUserApiResponse) *twitterUserTooltipDa
 	data.Username = user.Username
 	data.Description = user.Description
 	data.Followers = humanize.Number(user.Followers)
-	data.Thumbnail = user.ProfileImageUrl
+	data.Thumbnail = strings.Replace(user.ProfileImageUrl, "_normal", "", 1)
 
 	return data
 }

--- a/internal/resolvers/twitter/api.go
+++ b/internal/resolvers/twitter/api.go
@@ -112,7 +112,10 @@ func getUserByName(userName, bearer string) (*TwitterUserApiResponse, error) {
 		return nil, errors.New("unable to process response")
 	}
 
-	// Do modifications to response
+	/* By default, Twitter returns a low resolution image.
+	 * This modification removes "_normal" to get the original sized image, based on Twitter's API documentation:
+	 * https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/user-profile-images-and-banners
+	 */
 	user.ProfileImageUrl = strings.Replace(user.ProfileImageUrl, "_normal", "", 1)
 
 	return user, nil


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Note: **I've not tested this fix.**

As per @leon-richardt's link on issue #130, Twitter recommends modifying the received URL to get a higher quality profile picture. This also works for users who haven't set a profile picture.

Closes #130 