### PR TITLE
fix: don't check for success oEmbed status

### DIFF
--- a/internal/resolvers/oembed/README.md
+++ b/internal/resolvers/oembed/README.md
@@ -1,7 +1,7 @@
 # oEmbed
 
-The oEmbed resolver requires a `resolvers.json` to be loadable from the application.
+The oEmbed resolver requires a `providers.json` to be loadable from the application.
 
-The `CHATTERINO_API_OEMBED_PROVIDERS_PATH` environment variable can be set to change where the file is loaded from, and if no environment variable is set it tries to load the file from `./resolvers.json`.
+The `CHATTERINO_API_OEMBED_PROVIDERS_PATH` environment variable can be set to change where the file is loaded from, and if no environment variable is set it tries to load the file from `./providers.json`.
 
-If the Facebook and Instagram resolvers are part of your `resolvers.json` file, you can specify the `CHATTERINO_API_OEMBED_FACEBOOK_APP_ID` and `CHATTERINO_API_OEMBED_FACEBOOK_APP_SECRET` environment variables to grant Authorization for those requests, giving you rich data for Facebook and Instagram posts.
+If Facebook and Instagram oEmbed providers are in your `providers.json` file, you can specify the `CHATTERINO_API_OEMBED_FACEBOOK_APP_ID` and `CHATTERINO_API_OEMBED_FACEBOOK_APP_SECRET` environment variables to grant Authorization for those requests, giving you rich data for Facebook and Instagram posts.

--- a/internal/resolvers/oembed/load.go
+++ b/internal/resolvers/oembed/load.go
@@ -40,7 +40,7 @@ func load(requestedURL string, r *http.Request) (interface{}, time.Duration, err
 		}, cache.NoSpecialDur, nil
 	}
 
-	if data.Status > http.StatusMultipleChoices {
+	if data.Status > http.StatusOK {
 		log.Printf("[oEmbed] Skipping url %s because status code is %d\n", requestedURL, data.Status)
 		return &resolver.Response{
 			Status:  data.Status,

--- a/internal/resolvers/oembed/load.go
+++ b/internal/resolvers/oembed/load.go
@@ -40,7 +40,7 @@ func load(requestedURL string, r *http.Request) (interface{}, time.Duration, err
 		}, cache.NoSpecialDur, nil
 	}
 
-	if data.Status < http.StatusOK || data.Status > http.StatusMultipleChoices {
+	if data.Status > http.StatusMultipleChoices {
 		log.Printf("[oEmbed] Skipping url %s because status code is %d\n", requestedURL, data.Status)
 		return &resolver.Response{
 			Status:  data.Status,


### PR DESCRIPTION
Pull request checklist:

- [ ] `CHANGELOG.md` was updated, if applicable

# Description

There's currently an issue where no oEmbeds will show up because we require status code to be 200 but oEmbed library used doesn't return status code *unless* it's > 200:
https://github.com/dyatlov/go-oembed/blob/a57c85b3b37c0375d869f298387d9bcf5bb437c7/oembed/oembed.go#L71

This PR removes the check and allows oEmbed to work properly