### PR TITLE
fix: Skip lilliput if below maxThumbnailSize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Skip lilliput if image is below maxThumbnailSize. (#184)
+
 ## 1.2.0
 
 - Breaking: YouTube environment variable has been renamed (`CHATTERINO_API_YOUTUBE_API_KEY`).

--- a/pkg/thumbnail/thumbnail_unix.go
+++ b/pkg/thumbnail/thumbnail_unix.go
@@ -46,48 +46,48 @@ func buildThumbnailByteArray(inputBuf []byte, resp *http.Response) ([]byte, erro
 	// If the final image does not fit within this buffer, then we fall back to providing a static thumbnail
 	outputImg := make([]byte, 2*1024*1024)
 
-	// Only trigger if original image has higher values than maxThumbnailSize
-	if newWidth > maxThumbnailSize || newHeight > maxThumbnailSize {
-		// don't transcode (use existing type)
-		outputType := "." + strings.ToLower(decoder.Description())
+	// We don't need to resize image nor does it need to be passed through lilliput.
+	// Only resize if the original image has bigger dimensions than maxThumbnailSize
+	if newWidth < maxThumbnailSize && newHeight < maxThumbnailSize {
+		return inputBuf, nil
+	}
 
-		/* Preserve aspect ratio is from previous module, thanks nfnt/resize.
-		 * (https://github.com/nfnt/resize/blob/83c6a9932646f83e3267f353373d47347b6036b2/thumbnail.go#L27)
-		 */
+	// don't transcode (use existing type)
+	outputType := "." + strings.ToLower(decoder.Description())
 
-		// Preserve aspect ratio
-		if newWidth > maxThumbnailSize {
-			newHeight = newHeight * maxThumbnailSize / newWidth
-			if newHeight < 1 {
-				newHeight = 1
-			}
-			newWidth = maxThumbnailSize
+	/* Preserve aspect ratio is from previous module, thanks nfnt/resize.
+	 * (https://github.com/nfnt/resize/blob/83c6a9932646f83e3267f353373d47347b6036b2/thumbnail.go#L27)
+	 */
+
+	// Preserve aspect ratio
+	if newWidth > maxThumbnailSize {
+		newHeight = newHeight * maxThumbnailSize / newWidth
+		if newHeight < 1 {
+			newHeight = 1
 		}
+		newWidth = maxThumbnailSize
+	}
 
-		if newHeight > maxThumbnailSize {
-			newWidth = newWidth * maxThumbnailSize / newHeight
-			if newWidth < 1 {
-				newWidth = 1
-			}
-			newHeight = maxThumbnailSize
+	if newHeight > maxThumbnailSize {
+		newWidth = newWidth * maxThumbnailSize / newHeight
+		if newWidth < 1 {
+			newWidth = 1
 		}
+		newHeight = maxThumbnailSize
+	}
 
-		opts := &lilliput.ImageOptions{
-			FileType:      outputType,
-			Width:         newWidth,
-			Height:        newHeight,
-			ResizeMethod:  lilliput.ImageOpsResize,
-			EncodeOptions: encodeOptions[outputType],
-		}
+	opts := &lilliput.ImageOptions{
+		FileType:      outputType,
+		Width:         newWidth,
+		Height:        newHeight,
+		ResizeMethod:  lilliput.ImageOpsResize,
+		EncodeOptions: encodeOptions[outputType],
+	}
 
-		// resize and transcode image
-		outputImg, err = ops.Transform(decoder, opts, outputImg)
-		if err != nil {
-			return []byte{}, fmt.Errorf("could not transform image from url: %s", resp.Request.URL)
-		}
-	} else {
-		// We don't need to resize image nor does it need to be passed through lilliput.
-		outputImg = inputBuf
+	// resize and transcode image
+	outputImg, err = ops.Transform(decoder, opts, outputImg)
+	if err != nil {
+		return []byte{}, fmt.Errorf("could not transform image from url: %s", resp.Request.URL)
 	}
 
 	return outputImg, nil


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

If image is below maxThumbnailSize, might as well just use the inputBuf.