### PR TITLE
Include correct `type` field in emoteset response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Added link preview support for 7tv emote links. (#155)
 - Skip lilliput if image is below maxThumbnailSize. (#184)
-- Dev: Change Emote Set backend from `twitchemotes.com` to the Twitch Helix API. (#175)
+- Dev: Change Emote Set backend from `twitchemotes.com` to the Twitch Helix API. (#175, #188)
 
 ## 1.2.0
 

--- a/internal/routes/twitchemotes/route.go
+++ b/internal/routes/twitchemotes/route.go
@@ -91,6 +91,7 @@ func doTwitchemotesRequest(setID string, r *http.Request) (interface{}, time.Dur
 	emoteSet := EmoteSet{
 		ChannelName: username,
 		ChannelID:   emote.OwnerID,
+		Type:        emote.EmoteType,
 	}
 
 	return utils.MarshalNoDur(&emoteSet)


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

It might be useful in the future if we decide to switch back to this API for emoteset requests.
