### PR TITLE
Fix Twitch clip domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Twitch clips under `www.twitch.tv` domain work again. (#189)
 - Added link preview support for 7tv emote links. (#155)
 - Skip lilliput if image is below maxThumbnailSize. (#184)
 - Dev: Change Emote Set backend from `twitchemotes.com` to the Twitch Helix API. (#175)

--- a/internal/resolvers/twitch/check.go
+++ b/internal/resolvers/twitch/check.go
@@ -4,7 +4,7 @@ import (
 	"net/url"
 	"regexp"
 
-	"github.com/Chatterino/api/pkg/utils"
+	"github.com/Chatterino/api/pkg/resolver"
 )
 
 var (
@@ -19,17 +19,18 @@ func check(url *url.URL) bool {
 		return false
 	}
 
+	match, domain := resolver.MatchesHosts(url, domains)
+	if !match {
+		return false
+	}
+
 	// Find clips that look like https://clips.twitch.tv/SlugHere
-	if utils.IsDomain(url, "clips.twitch.tv") {
+	if domain == "clips.twitch.tv" {
 		// matches[1] contains "StreamerName/clip/" - we don't want it in this check though
 		return matches[1] == ""
 	}
 
 	// Find clips that look like https://twitch.tv/StreamerName/clip/SlugHere
-	if utils.IsDomain(url, "twitch.tv") {
-		// matches[1] contains "StreamerName/clip/" - we need it in this check
-		return matches[1] != ""
-	}
-
-	return false
+	// matches[1] contains "StreamerName/clip/" - we need it in this check
+	return matches[1] != ""
 }

--- a/internal/resolvers/twitch/resolver.go
+++ b/internal/resolvers/twitch/resolver.go
@@ -34,6 +34,12 @@ var (
 
 	twitchClipsTooltip = template.Must(template.New("twitchclipsTooltip").Parse(twitchClipsTooltipString))
 
+	domains = map[string]struct{}{
+		"twitch.tv":       {},
+		"www.twitch.tv":   {},
+		"clips.twitch.tv": {},
+	}
+
 	clipCache = cache.New("twitchclip", load, 1*time.Hour)
 
 	helixAPI TwitchAPIClient


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Using map of domains instead of checks on 2 domains to also include `www.twitch.tv`, which is apparently valid.
