### PR TITLE
feat: Make maxThumbnailSize configurable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- MaxThumbnailSize is now configurable using the `max-thumbnail-size` variable. (#195)
+- MaxThumbnailSize is now configurable using the `max-thumbnail-size` config value. (#195)
 - Twitch clips under `www.twitch.tv` domain work again. (#189)
 - Imgur thumbnails are now proxied as well. (#187)
 - Added link preview support for 7tv emote links. (#155)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- MaxThumbnailSize is now configurable using the `max-thumbnail-size` variable. (#195)
 - Twitch clips under `www.twitch.tv` domain work again. (#189)
 - Imgur thumbnails are now proxied as well. (#187)
 - Added link preview support for 7tv emote links. (#155)

--- a/config.yaml
+++ b/config.yaml
@@ -13,6 +13,9 @@
 # Can increase memory usage by a lot.
 #enable-lilliput: true
 
+# Maximum width/height pixel size count of the thumbnails sent to the clients.
+#max-thumbnail-size: 300
+
 
 # Discord token, provides rich information for Discord invite links
 #discord-token: ""

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -64,6 +64,7 @@ func init() {
 	pflag.StringP("bind-address", "l", ":1234", "Address to which API will bind and start listening on")
 	pflag.Uint64("max-content-length", 5*1024*1024, "Max content size in bytes - requests with body bigger than this value will be skipped")
 	pflag.Bool("enable-lilliput", true, "When enabled, will attempt to use lilliput library for building animated thumbnails. Can increase memory usage by a lot")
+	pflag.Uint("max-thumbnail-size", 300, "Maximum width/height pixel size count of the thumbnails sent to the clients.")
 	pflag.String("discord-token", "", "Discord token")
 	pflag.String("twitch-client-id", "", "Twitch client ID")
 	pflag.String("twitch-client-secret", "", "Twitch client secret")

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -7,6 +7,7 @@ type APIConfig struct {
 	BindAddress      string `mapstructure:"bind-address" json:"bind-address"`
 	MaxContentLength uint64 `mapstructure:"max-content-length" json:"max-content-length"`
 	EnableLilliput   bool   `mapstructure:"enable-lilliput" json:"enable-lilliput"`
+	MaxThumbnailSize uint   `mapstructure:"max-thumbnail-size" json:"max-thumbnail-size"`
 
 	// Secrets
 

--- a/pkg/thumbnail/thumbnail.go
+++ b/pkg/thumbnail/thumbnail.go
@@ -28,11 +28,6 @@ var (
 	cfg config.APIConfig
 )
 
-const (
-	// max width or height the thumbnail will be resized to
-	maxThumbnailSize = 300
-)
-
 func InitializeConfig(passedCfg config.APIConfig) {
 	cfg = passedCfg
 }
@@ -44,7 +39,7 @@ func buildStaticThumbnailByteArray(inputBuf []byte, resp *http.Response) ([]byte
 		return []byte{}, fmt.Errorf("could not decode image from url: %s", resp.Request.URL)
 	}
 
-	resized := resize.Thumbnail(maxThumbnailSize, maxThumbnailSize, image, resize.Bilinear)
+	resized := resize.Thumbnail(cfg.MaxThumbnailSize, cfg.MaxThumbnailSize, image, resize.Bilinear)
 	buffer := new(bytes.Buffer)
 	if resp.Header.Get("content-type") == "image/png" {
 		err = png.Encode(buffer, resized)

--- a/pkg/thumbnail/thumbnail_unix.go
+++ b/pkg/thumbnail/thumbnail_unix.go
@@ -48,7 +48,7 @@ func buildThumbnailByteArray(inputBuf []byte, resp *http.Response) ([]byte, erro
 
 	// We don't need to resize image nor does it need to be passed through lilliput.
 	// Only resize if the original image has bigger dimensions than maxThumbnailSize
-	if newWidth < maxThumbnailSize && newHeight < maxThumbnailSize {
+	if newWidth < cfg.MaxThumbnailSize && newHeight < cfg.MaxThumbnailSize {
 		return inputBuf, nil
 	}
 
@@ -60,20 +60,20 @@ func buildThumbnailByteArray(inputBuf []byte, resp *http.Response) ([]byte, erro
 	 */
 
 	// Preserve aspect ratio
-	if newWidth > maxThumbnailSize {
-		newHeight = newHeight * maxThumbnailSize / newWidth
+	if newWidth > cfg.MaxThumbnailSize {
+		newHeight = newHeight * cfg.MaxThumbnailSize / newWidth
 		if newHeight < 1 {
 			newHeight = 1
 		}
-		newWidth = maxThumbnailSize
+		newWidth = cfg.MaxThumbnailSize
 	}
 
-	if newHeight > maxThumbnailSize {
-		newWidth = newWidth * maxThumbnailSize / newHeight
+	if newHeight > cfg.MaxThumbnailSize {
+		newWidth = newWidth * cfg.MaxThumbnailSize / newHeight
 		if newWidth < 1 {
 			newWidth = 1
 		}
-		newHeight = maxThumbnailSize
+		newHeight = cfg.MaxThumbnailSize
 	}
 
 	opts := &lilliput.ImageOptions{

--- a/pkg/thumbnail/thumbnail_unix.go
+++ b/pkg/thumbnail/thumbnail_unix.go
@@ -46,9 +46,12 @@ func buildThumbnailByteArray(inputBuf []byte, resp *http.Response) ([]byte, erro
 	// If the final image does not fit within this buffer, then we fall back to providing a static thumbnail
 	outputImg := make([]byte, 2*1024*1024)
 
+	// lilliput has the height & width values in int, which means we're converting uint to int.
+	maxThumbnailSizeInt := int(cfg.MaxThumbnailSize)
+
 	// We don't need to resize image nor does it need to be passed through lilliput.
 	// Only resize if the original image has bigger dimensions than maxThumbnailSize
-	if newWidth < cfg.MaxThumbnailSize && newHeight < cfg.MaxThumbnailSize {
+	if newWidth < maxThumbnailSizeInt && newHeight < maxThumbnailSizeInt {
 		return inputBuf, nil
 	}
 
@@ -60,20 +63,20 @@ func buildThumbnailByteArray(inputBuf []byte, resp *http.Response) ([]byte, erro
 	 */
 
 	// Preserve aspect ratio
-	if newWidth > cfg.MaxThumbnailSize {
-		newHeight = newHeight * cfg.MaxThumbnailSize / newWidth
+	if newWidth > maxThumbnailSizeInt {
+		newHeight = newHeight * maxThumbnailSizeInt / newWidth
 		if newHeight < 1 {
 			newHeight = 1
 		}
-		newWidth = cfg.MaxThumbnailSize
+		newWidth = maxThumbnailSizeInt
 	}
 
-	if newHeight > cfg.MaxThumbnailSize {
-		newWidth = newWidth * cfg.MaxThumbnailSize / newHeight
+	if newHeight > maxThumbnailSizeInt {
+		newWidth = newWidth * maxThumbnailSizeInt / newHeight
 		if newWidth < 1 {
 			newWidth = 1
 		}
-		newHeight = cfg.MaxThumbnailSize
+		newHeight = maxThumbnailSizeInt
 	}
 
 	opts := &lilliput.ImageOptions{

--- a/pkg/thumbnail/thumbnail_unix.go
+++ b/pkg/thumbnail/thumbnail_unix.go
@@ -47,11 +47,11 @@ func buildThumbnailByteArray(inputBuf []byte, resp *http.Response) ([]byte, erro
 	outputImg := make([]byte, 2*1024*1024)
 
 	// lilliput has the height & width values in int, which means we're converting uint to int.
-	maxThumbnailSizeInt := int(cfg.MaxThumbnailSize)
+	maxThumbnailSize := int(cfg.MaxThumbnailSize)
 
 	// We don't need to resize image nor does it need to be passed through lilliput.
 	// Only resize if the original image has bigger dimensions than maxThumbnailSize
-	if newWidth < maxThumbnailSizeInt && newHeight < maxThumbnailSizeInt {
+	if newWidth < maxThumbnailSize && newHeight < maxThumbnailSize {
 		return inputBuf, nil
 	}
 
@@ -63,20 +63,20 @@ func buildThumbnailByteArray(inputBuf []byte, resp *http.Response) ([]byte, erro
 	 */
 
 	// Preserve aspect ratio
-	if newWidth > maxThumbnailSizeInt {
-		newHeight = newHeight * maxThumbnailSizeInt / newWidth
+	if newWidth > maxThumbnailSize {
+		newHeight = newHeight * maxThumbnailSize / newWidth
 		if newHeight < 1 {
 			newHeight = 1
 		}
-		newWidth = maxThumbnailSizeInt
+		newWidth = maxThumbnailSize
 	}
 
-	if newHeight > maxThumbnailSizeInt {
-		newWidth = newWidth * maxThumbnailSizeInt / newHeight
+	if newHeight > maxThumbnailSize {
+		newWidth = newWidth * maxThumbnailSize / newHeight
 		if newWidth < 1 {
 			newWidth = 1
 		}
-		newHeight = maxThumbnailSizeInt
+		newHeight = maxThumbnailSize
 	}
 
 	opts := &lilliput.ImageOptions{


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

**Reason for using `uint` instead of `uint64`:**
https://pkg.go.dev/github.com/nfnt/resize@v0.0.0-20180221191011-83c6a9932646?utm_source=gopls#Thumbnail
(nfnt/resize wants uint)

Also, lilliput wants int for some reason so we're doing a very not-so-safe conversion here: https://github.com/Chatterino/api/pull/195/commits/f78081d1200337703730f907450361b95e271816#diff-eef76937259b12ac1bd8203cd1712be3693ba66cf644d0e555ed0d33f05536baR50

Closes #183 