### PR TITLE
Fix panic upon failing to refresh app access token

### DIFF
--- a/internal/twitchapiclient/token_refresh.go
+++ b/internal/twitchapiclient/token_refresh.go
@@ -13,7 +13,7 @@ func initAppAccessToken(helixAPI *helix.Client, tokenFetched chan struct{}) {
 	response, err := helixAPI.RequestAppAccessToken([]string{})
 
 	if err != nil {
-		log.Fatalf("[Helix] Error requesting app access token: %s, response: %# v\n", err.Error(), response)
+		log.Fatalf("[Helix] Error requesting app access token: %s", err)
 	}
 
 	log.Printf("[Helix] Requested access token, status: %d, expires in: %d", response.StatusCode, response.Data.ExpiresIn)
@@ -26,7 +26,7 @@ func initAppAccessToken(helixAPI *helix.Client, tokenFetched chan struct{}) {
 	for range ticker.C {
 		response, err := helixAPI.RequestAppAccessToken([]string{})
 		if err != nil {
-			log.Printf("[Helix] Failed to re-request app access token from ticker, response: %# v\n", response)
+			log.Printf("[Helix] Failed to re-request app access token from ticker: %s", err)
 			continue
 		}
 		log.Printf("[Helix] Re-requested access token from ticker, status: %d, expires in: %d", response.StatusCode, response.Data.ExpiresIn)

--- a/internal/twitchapiclient/token_refresh.go
+++ b/internal/twitchapiclient/token_refresh.go
@@ -13,7 +13,7 @@ func initAppAccessToken(helixAPI *helix.Client, tokenFetched chan struct{}) {
 	response, err := helixAPI.RequestAppAccessToken([]string{})
 
 	if err != nil {
-		log.Fatalf("[Helix] Error requesting app access token: %s", err.Error())
+		log.Fatalf("[Helix] Error requesting app access token: %s, response: %# v\n", err.Error(), response)
 	}
 
 	log.Printf("[Helix] Requested access token, status: %d, expires in: %d", response.StatusCode, response.Data.ExpiresIn)
@@ -26,7 +26,7 @@ func initAppAccessToken(helixAPI *helix.Client, tokenFetched chan struct{}) {
 	for range ticker.C {
 		response, err := helixAPI.RequestAppAccessToken([]string{})
 		if err != nil {
-			log.Printf("[Helix] Failed to re-request app access token from ticker, status: %d", response.StatusCode)
+			log.Printf("[Helix] Failed to re-request app access token from ticker, response: %# v\n", response)
 			continue
 		}
 		log.Printf("[Helix] Re-requested access token from ticker, status: %d, expires in: %d", response.StatusCode, response.Data.ExpiresIn)

--- a/internal/twitchapiclient/token_refresh.go
+++ b/internal/twitchapiclient/token_refresh.go
@@ -13,7 +13,7 @@ func initAppAccessToken(helixAPI *helix.Client, tokenFetched chan struct{}) {
 	response, err := helixAPI.RequestAppAccessToken([]string{})
 
 	if err != nil {
-		log.Fatalf("[Helix] Error requesting app access token: %s , \n %s", err.Error(), response.Error)
+		log.Fatalf("[Helix] Error requesting app access token: %s", err.Error())
 	}
 
 	log.Printf("[Helix] Requested access token, status: %d, expires in: %d", response.StatusCode, response.Data.ExpiresIn)


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

According to [nicklaw5/helix's source](https://github.com/nicklaw5/helix/blob/main/authentication.go#L65-L67) I'm pretty sure that `response` will/should™ be `nil` when `err != nil`, so we shouldn't try to access that variable's properties. Maybe we shouldn't even print these anyway(?)
