### PR TITLE
Removed dislikes from rich YouTube tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- YouTube: Removed dislike count from rich tooltips since YouTube removed it. (#243)
 - Twitter: Blacklist special pages from being resolved as user pages. (#220)
 - Updated Facebook & Instagram endpoints to oembed v10. (#201)
 

--- a/internal/resolvers/youtube/load.go
+++ b/internal/resolvers/youtube/load.go
@@ -46,7 +46,6 @@ func loadVideos(videoID string, r *http.Request) (interface{}, time.Duration, er
 		PublishDate:  humanize.CreationDateRFC3339(video.Snippet.PublishedAt),
 		Views:        humanize.Number(video.Statistics.ViewCount),
 		LikeCount:    humanize.Number(video.Statistics.LikeCount),
-		DislikeCount: humanize.Number(video.Statistics.DislikeCount),
 	}
 
 	var tooltip bytes.Buffer

--- a/internal/resolvers/youtube/model.go
+++ b/internal/resolvers/youtube/model.go
@@ -7,7 +7,6 @@ type youtubeVideoTooltipData struct {
 	PublishDate  string
 	Views        string
 	LikeCount    string
-	DislikeCount string
 }
 
 type youtubeChannelTooltipData struct {

--- a/internal/resolvers/youtube/resolver.go
+++ b/internal/resolvers/youtube/resolver.go
@@ -26,7 +26,7 @@ const (
 <br><b>Duration:</b> {{.Duration}}
 <br><b>Published:</b> {{.PublishDate}}
 <br><b>Views:</b> {{.Views}}
-<br><span style="color: #2ecc71;">{{.LikeCount}} likes</span>&nbsp;•&nbsp;<span style="color: #e74c3c;">{{.DislikeCount}} dislikes</span>
+<br><span style="color: #2ecc71;">{{.LikeCount}} likes</span>
 </div>
 `
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Since, as described in the email we've got, YouTube is removing dislike count on 14th Dec 2021. Since we're going to lose the functionality, I've went ahead sooner and removed it already.
![so empty on this thumbnail](https://cdn.zneix.eu/zXkwbAu.png)
