### PR TITLE
ref(twitter): clearer message and doc (error code 50)

### DIFF
--- a/internal/resolvers/twitter/load.go
+++ b/internal/resolvers/twitter/load.go
@@ -54,14 +54,13 @@ func loadTwitterUser(userName string, r *http.Request) (interface{}, time.Durati
 
 	userResp, err := getUserByName(userName, bearerKey)
 	if err != nil {
+		// Error code for "User not found.", as described here:
+		// https://developer.twitter.com/en/support/twitter-api/error-troubleshooting#error-codes
 		if err.Error() == "50" {
-			var response resolver.Response
-			unmarshalErr := json.Unmarshal(resolver.NoLinkInfoFound, &response)
-			if unmarshalErr != nil {
-				log.Println("Error unmarshalling prebuilt response:", unmarshalErr.Error())
-			}
-
-			return &response, 1 * time.Hour, nil
+			return &resolver.Response{
+				Status:  http.StatusNotFound,
+				Message: "Error: User not found.",
+			}, cache.NoSpecialDur, nil
 		}
 
 		return &resolver.Response{

--- a/internal/resolvers/twitter/load.go
+++ b/internal/resolvers/twitter/load.go
@@ -59,7 +59,7 @@ func loadTwitterUser(userName string, r *http.Request) (interface{}, time.Durati
 		if err.Error() == "50" {
 			return &resolver.Response{
 				Status:  http.StatusNotFound,
-				Message: "Error: User not found.",
+				Message: "Error: Twitter user not found.",
 			}, cache.NoSpecialDur, nil
 		}
 


### PR DESCRIPTION
Pull request checklist:

- [x] ~~`CHANGELOG.md` was updated, if applicable~~ (n/a in my opinion, but I can add one if anyone would like me to)

# Description

Commit message:
> The magic value of "50" was not documented anywhere previously, causing
some confusion. Additionally, this commit improves the error message
given in the returned tooltip to be more specific than the standard
prebuilt response of just "No link info found".

