### PR TITLE
Add "age restricted" label to age restricted YouTube videos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- YouTube: Added a red `AGE RESTRICTED` label to the YouTube video tooltip. (#251)
 - YouTube: Removed dislike count from rich tooltips since YouTube removed it. (#243)
 - Twitter: Blacklist special pages from being resolved as user pages. (#220)
 - Twitch: Handle Twitch clips from `m.twitch.tv` domain. (#239)

--- a/internal/resolvers/youtube/load.go
+++ b/internal/resolvers/youtube/load.go
@@ -39,13 +39,22 @@ func loadVideos(videoID string, r *http.Request) (interface{}, time.Duration, er
 		return &resolver.Response{Status: 500, Message: "video unavailable"}, cache.NoSpecialDur, nil
 	}
 
+	// Check if a video is age resricted: https://stackoverflow.com/a/33750307
+	var ageRestricted = false
+	if video.ContentDetails.ContentRating != nil {
+		if video.ContentDetails.ContentRating.YtRating == "ytAgeRestricted" {
+			ageRestricted = true
+		}
+	}
+
 	data := youtubeVideoTooltipData{
-		Title:        video.Snippet.Title,
-		ChannelTitle: video.Snippet.ChannelTitle,
-		Duration:     humanize.DurationPT(video.ContentDetails.Duration),
-		PublishDate:  humanize.CreationDateRFC3339(video.Snippet.PublishedAt),
-		Views:        humanize.Number(video.Statistics.ViewCount),
-		LikeCount:    humanize.Number(video.Statistics.LikeCount),
+		Title:         video.Snippet.Title,
+		ChannelTitle:  video.Snippet.ChannelTitle,
+		Duration:      humanize.DurationPT(video.ContentDetails.Duration),
+		PublishDate:   humanize.CreationDateRFC3339(video.Snippet.PublishedAt),
+		Views:         humanize.Number(video.Statistics.ViewCount),
+		LikeCount:     humanize.Number(video.Statistics.LikeCount),
+		AgeRestricted: ageRestricted,
 	}
 
 	var tooltip bytes.Buffer

--- a/internal/resolvers/youtube/model.go
+++ b/internal/resolvers/youtube/model.go
@@ -1,12 +1,13 @@
 package youtube
 
 type youtubeVideoTooltipData struct {
-	Title        string
-	ChannelTitle string
-	Duration     string
-	PublishDate  string
-	Views        string
-	LikeCount    string
+	Title         string
+	ChannelTitle  string
+	Duration      string
+	PublishDate   string
+	Views         string
+	LikeCount     string
+	AgeRestricted bool
 }
 
 type youtubeChannelTooltipData struct {

--- a/internal/resolvers/youtube/resolver.go
+++ b/internal/resolvers/youtube/resolver.go
@@ -26,6 +26,7 @@ const (
 <br><b>Duration:</b> {{.Duration}}
 <br><b>Published:</b> {{.PublishDate}}
 <br><b>Views:</b> {{.Views}}
+{{ if .AgeRestricted }}<br><b><span style="color: red;">AGE RESTRICTED</span></b>{{ end }}
 <br><span style="color: #2ecc71;">{{.LikeCount}} likes</span>
 </div>
 `


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Shows a red `AGE RESTRICTED` label between `Views` and likes count for age restricted YouTube videos.

Reference:
- https://stackoverflow.com/a/33750307
- https://pkg.go.dev/google.golang.org/api@v0.63.0/youtube/v3?utm_source=gopls#ContentRating.YtRating
- https://developers.google.com/youtube/v3/docs/videos#contentDetails.contentRating.ytRating

NOTE: while go.dev link mentions `ytUnspecified` as a possible value, official API docs do not mention it (anymore?), so I didn't bother handling that.

Example of an age restricted video (safe for stream ![Clue](https://cdn.betterttv.net/emote/615d9d21b63cc97ee6d512e0/1x)): https://www.youtube.com/watch?v=SIM0e-R5y_g