### PR TITLE
Added comment count to YouTube tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- YouTube: Added comment count to rich video tooltips. (#252)
 - YouTube: Added a red `AGE RESTRICTED` label to the YouTube video tooltip. (#251)
 - YouTube: Removed dislike count from rich tooltips since YouTube removed it. (#243)
 - Twitter: Blacklist special pages from being resolved as user pages. (#220)

--- a/internal/resolvers/youtube/load.go
+++ b/internal/resolvers/youtube/load.go
@@ -54,6 +54,7 @@ func loadVideos(videoID string, r *http.Request) (interface{}, time.Duration, er
 		PublishDate:   humanize.CreationDateRFC3339(video.Snippet.PublishedAt),
 		Views:         humanize.Number(video.Statistics.ViewCount),
 		LikeCount:     humanize.Number(video.Statistics.LikeCount),
+		CommentCount:  humanize.Number(video.Statistics.CommentCount),
 		AgeRestricted: ageRestricted,
 	}
 

--- a/internal/resolvers/youtube/model.go
+++ b/internal/resolvers/youtube/model.go
@@ -7,6 +7,7 @@ type youtubeVideoTooltipData struct {
 	PublishDate   string
 	Views         string
 	LikeCount     string
+	CommentCount  string
 	AgeRestricted bool
 }
 

--- a/internal/resolvers/youtube/resolver.go
+++ b/internal/resolvers/youtube/resolver.go
@@ -27,7 +27,7 @@ const (
 <br><b>Published:</b> {{.PublishDate}}
 <br><b>Views:</b> {{.Views}}
 {{ if .AgeRestricted }}<br><b><span style="color: red;">AGE RESTRICTED</span></b>{{ end }}
-<br><span style="color: #2ecc71;">{{.LikeCount}} likes</span>
+<br><span style="color: #2ecc71;">{{.LikeCount}} likes</span>&nbsp;•&nbsp;<span style="color: #808892;">{{.CommentCount}} comments</span>
 </div>
 `
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

I figured it could be a nice touch, especially since there's space available in the tooltip after dislike count was (sadly) removed.

Preview, not sure if we want this grey, perhaps another color can work better(?):
![pajaCCool Clap](https://cdn.zneix.eu/CgBKv8y.png)
