### PR TITLE
Remove actions/checkout from changelog check action

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       # Gives an error if there's no change in the changelog (except using label)
       - name: Changelog check
-        uses: dangoslen/changelog-enforcer@v2.3.1
+        uses: dangoslen/changelog-enforcer@v3
         with:
           changeLogPath: 'CHANGELOG.md'
           skipLabels: 'no changelog entry needed, dependencies'

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -9,8 +9,6 @@ jobs:
   check-changelog:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.4.0
-
       # Gives an error if there's no change in the changelog (except using label)
       - name: Changelog check
         uses: dangoslen/changelog-enforcer@v2.3.1


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

With #255, changelog enforcer action updates to v3; according to their [changelog](https://github.com/dangoslen/changelog-enforcer/blob/master/CHANGELOG.md#v300) `actions/checkout` is no longer required.
Wanna see first what happens if I remove it on lower version.
