### PR TITLE
feat: auto-rotate thumbnails based on metadata

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         go: [1.18, 1.19]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-22.04, windows-latest, macos-latest]
 
     steps:
       - uses: actions/setup-go@v3
@@ -25,7 +25,15 @@ jobs:
 
       - uses: actions/checkout@v3
 
-      - name: Get dependencies
+      - name: Get external dependencies (Ubuntu)
+        if: matrix.os == 'ubuntu-22.04'
+        run: sudo apt update && sudo apt -y install build-essential libvips-dev
+
+      - name: Get external dependencies (MacOS)
+        if: matrix.os == 'macos-latest'
+        run: brew install vips
+
+      - name: Get Go dependencies
         run: |
           go get -v -t -d ./...
 
@@ -40,11 +48,11 @@ jobs:
         run: go test -v -tags migrationtest ./...
 
       - name: Generate code coverage
-        if: matrix.os == 'ubuntu-latest' && matrix.go == '1.19'
+        if: matrix.os == 'ubuntu-22.04' && matrix.go == '1.19'
         run: go test -race -v -count=1 -coverprofile=coverage.out -tags test ./...
 
       - name: Upload Test Coverage
-        if: matrix.os == 'ubuntu-latest' && matrix.go == '1.19'
+        if: matrix.os == 'ubuntu-22.04' && matrix.go == '1.19'
         uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true
@@ -57,7 +65,7 @@ jobs:
 
   create-release:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: startsWith(github.ref, 'refs/tags/')
 
     steps:
@@ -67,7 +75,7 @@ jobs:
 
       - uses: actions/download-artifact@v3
         with:
-          name: chatterino-api-1.19-ubuntu-latest
+          name: chatterino-api-1.19-ubuntu-22.04
           path: bins/ubuntu/
 
       - uses: actions/download-artifact@v3

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,7 +21,7 @@ jobs:
   # Run tests.
   # See also https://docs.docker.com/docker-hub/builds/automated-testing/
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3
@@ -38,7 +38,7 @@ jobs:
   push:
     needs: test
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event_name == 'push'
 
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:
@@ -25,6 +25,9 @@ jobs:
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: sudo apt update && sudo apt -y install build-essential libvips-dev
 
       # This will install the staticcheck version as described in the go.mod file
       - name: Install linter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Breaking: Go version 1.17 is now the minimum required version to build this. (#292)
+- Breaking: Thumbnail generation now requires libvips. See [docs/build.md](./docs/build.md) for prerequisite instructions. (#366)
 - Breaking: Resolver caches are now stored in PostgreSQL. See [docs/build.md](./docs/build.md) for prerequisite instructions. (#271)
 - YouTube: Added support for 'YouTube shorts' URLs. (#299)
 - Fix: SevenTV emotes now resolve correctly. (#281, #288, #307)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
-FROM golang:1.19 AS build
+FROM ubuntu:22.04 AS build
+ENV GOVER=1.19.2
 ADD . /src
-RUN cd /src/cmd/api && GOOS=linux GOARCH=amd64 go build -tags netgo -ldflags '-extldflags "-static"'
+RUN apt update && apt -y install libvips-dev wget build-essential
+RUN wget -qO- https://go.dev/dl/go$GOVER.linux-amd64.tar.gz | tar -C /src -xzf -
+RUN cd /src/cmd/api && /src/go/bin/go build
 
-FROM alpine:latest
+FROM ubuntu:22.04
 WORKDIR /app
 COPY --from=build /src/cmd/api/api /app/
-RUN apk add --no-cache ca-certificates
+RUN apt update && apt install -y ca-certificates libvips && apt clean
 CMD ["./api"]

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -114,6 +114,7 @@ func main() {
 
 	resolver.InitializeStaticResponses(ctx, cfg)
 	thumbnail.InitializeConfig(cfg)
+	defer thumbnail.Shutdown()
 
 	router := chi.NewRouter()
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -3,6 +3,9 @@
 ## Prerequisites
 
 1. Resolved links are stored in PostgreSQL, so you must have PostgreSQL installed and accessible for the user running the API. For Ubuntu, you would install it with `sudo apt install postgresql`, create a DB user for your system user (`sudo -upostgres createuser pajlada`), then create a db for the api (`sudo -upostgres createdb chatterino-api --owner pajlada`). Make sure to edit `dsn` in your [configuration](./config.md). Example, using the details above, `dsn:"host=/var/run/postgresql user=pajlada database=chatterino-api"`.
+2. You must have [`libvips`](https://github.com/libvips/libvips) >=8.12.0 installed for thumbnail generation. (Linux-exclusive)
+   On Ubuntu 22.04, this can be done with `sudo apt install libvips libvips-dev`.
+   Different distros or releases may require adding a PPA or building and installing from source.
 
 ## Build
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/PuerkitoBio/goquery v1.8.0
+	github.com/davidbyttow/govips/v2 v2.11.0
 	github.com/discord/lilliput v0.0.0-20210720001558-e1547514bd5f
 	github.com/dyatlov/go-oembed v0.0.0-20191103150536-a57c85b3b37c
 	github.com/frankban/quicktest v1.14.3
@@ -13,7 +14,6 @@ require (
 	github.com/jackc/pgconn v1.13.0
 	github.com/jackc/pgx/v4 v4.17.2
 	github.com/koffeinsource/go-imgur v0.3.0
-	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
 	github.com/nicklaw5/helix v1.25.0
 	github.com/pashagolub/pgxmock v1.8.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
@@ -71,6 +71,7 @@ require (
 	go.uber.org/multierr v1.6.0 // indirect
 	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa // indirect
 	golang.org/x/exp/typeparams v0.0.0-20220722155223-a9213eeb770e // indirect
+	golang.org/x/image v0.0.0-20200927104501-e162460cd6b5 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
 	golang.org/x/net v0.0.0-20220909164309-bea034e7d591 // indirect
 	golang.org/x/oauth2 v0.0.0-20220822191816-0ebed06d0094 // indirect

--- a/go.sum
+++ b/go.sum
@@ -108,6 +108,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davidbyttow/govips/v2 v2.11.0 h1:eJY+Sgt2LRVh6TFSNMnl5rrFkDfuToG5uE5aLSV1jvM=
+github.com/davidbyttow/govips/v2 v2.11.0/go.mod h1:goq38QD8XEMz2aWEeucEZqRxAWsemIN40vbUqfPfTAw=
 github.com/discord/lilliput v0.0.0-20210720001558-e1547514bd5f h1:vM63WJhNbdzbgQdZv+6aNy8TUvj7y3hxuYdIWB6SGro=
 github.com/discord/lilliput v0.0.0-20210720001558-e1547514bd5f/go.mod h1:0euuUBAD72MAYRm2ElLaG1h0nBR+CgpfnKc/U6y/uE8=
 github.com/dyatlov/go-oembed v0.0.0-20191103150536-a57c85b3b37c h1:MEV1LrQtCBGacXajlT4CSuYWbZuLl/qaZVqwoOmwAbU=
@@ -348,10 +350,9 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
-github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
 github.com/nicklaw5/helix v1.25.0 h1:Mrz537izZVsGdM3I46uGAAlslj61frgkhS/9xQqyT/M=
 github.com/nicklaw5/helix v1.25.0/go.mod h1:yvXZFapT6afIoxnAvlWiJiUMsYnoHl7tNs+t0bloAMw=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/pashagolub/pgxmock v1.8.0 h1:05JB+jng7yPdeC6i04i8TC4H1Kr7TfcFeQyf4JP6534=
 github.com/pashagolub/pgxmock v1.8.0/go.mod h1:kDkER7/KJdD3HQjNvFw5siwR7yREKmMvwf8VhAgTK5o=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
@@ -495,6 +496,8 @@ golang.org/x/exp/typeparams v0.0.0-20220722155223-a9213eeb770e h1:7Xs2YCOpMlNqSQ
 golang.org/x/exp/typeparams v0.0.0-20220722155223-a9213eeb770e/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
+golang.org/x/image v0.0.0-20200927104501-e162460cd6b5 h1:QelT11PB4FXiDEXucrfNckHoFxwt8USGY1ajP1ZF5lM=
+golang.org/x/image v0.0.0-20200927104501-e162460cd6b5/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -951,6 +954,7 @@ gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLks
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=

--- a/internal/resolvers/default/link_loader.go
+++ b/internal/resolvers/default/link_loader.go
@@ -124,7 +124,7 @@ func (l *LinkLoader) Load(ctx context.Context, urlString string, r *http.Request
 		Thumbnail: data.ImageSrc,
 	}
 
-	if thumbnail.IsSupportedThumbnail(resp.Header.Get("content-type")) {
+	if thumbnail.IsSupportedThumbnailType(resp.Header.Get("content-type")) {
 		response.Thumbnail = utils.FormatThumbnailURL(l.baseURL, r, resp.Request.URL.String())
 	}
 

--- a/internal/resolvers/default/thumbnail_loader.go
+++ b/internal/resolvers/default/thumbnail_loader.go
@@ -81,13 +81,15 @@ func (l *ThumbnailLoader) Load(ctx context.Context, urlString string, r *http.Re
 	}
 
 	var image []byte
+	tryAnimatedThumb := l.enableLilliput && thumbnail.IsAnimatedThumbnailType(contentType)
+
 	// attempt building an animated image
-	if l.enableLilliput {
+	if tryAnimatedThumb {
 		image, err = thumbnail.BuildAnimatedThumbnail(inputBuf, resp)
 	}
 
 	// fallback to static image if animated image building failed or is disabled
-	if !l.enableLilliput || err != nil {
+	if !tryAnimatedThumb || err != nil {
 		if err != nil {
 			log.Errorw("Error trying to build animated thumbnail, falling back to static thumbnail building",
 				"error", err)

--- a/internal/resolvers/default/thumbnail_loader.go
+++ b/internal/resolvers/default/thumbnail_loader.go
@@ -70,7 +70,7 @@ func (l *ThumbnailLoader) Load(ctx context.Context, urlString string, r *http.Re
 
 	contentType := resp.Header.Get("Content-Type")
 
-	if !thumbnail.IsSupportedThumbnail(contentType) {
+	if !thumbnail.IsSupportedThumbnailType(contentType) {
 		return resolver.UnsupportedThumbnailType, nil, nil, cache.NoSpecialDur, nil
 	}
 

--- a/pkg/thumbnail/thumbnail.go
+++ b/pkg/thumbnail/thumbnail.go
@@ -6,6 +6,7 @@ import (
 
 var (
 	supportedThumbnails = []string{"image/jpeg", "image/png", "image/gif", "image/webp"}
+	animatedThumbnails  = []string{"image/gif", "image/webp"}
 
 	cfg config.APIConfig
 )
@@ -18,4 +19,8 @@ func IsSupportedThumbnail(contentType string) bool {
 	}
 
 	return false
+}
+
+func IsAnimatedThumbnailType(contentType string) bool {
+	return utils.Contains(animatedThumbnails, contentType)
 }

--- a/pkg/thumbnail/thumbnail.go
+++ b/pkg/thumbnail/thumbnail.go
@@ -1,16 +1,7 @@
 package thumbnail
 
 import (
-	"bytes"
-	"fmt"
-	"image"
-	"image/gif"
-	"image/jpeg"
-	"image/png"
-	"net/http"
-
 	"github.com/Chatterino/api/pkg/config"
-	"github.com/nfnt/resize"
 )
 
 var (
@@ -18,33 +9,6 @@ var (
 
 	cfg config.APIConfig
 )
-
-func InitializeConfig(passedCfg config.APIConfig) {
-	cfg = passedCfg
-}
-
-// BuildStaticThumbnail is used when we fail to build an animated thumbnail using lilliput
-func BuildStaticThumbnail(inputBuf []byte, resp *http.Response) ([]byte, error) {
-	image, _, err := image.Decode(bytes.NewReader(inputBuf))
-	if err != nil {
-		return []byte{}, fmt.Errorf("could not decode image from url: %s", resp.Request.URL)
-	}
-
-	resized := resize.Thumbnail(cfg.MaxThumbnailSize, cfg.MaxThumbnailSize, image, resize.Bilinear)
-	buffer := new(bytes.Buffer)
-	if resp.Header.Get("content-type") == "image/png" {
-		err = png.Encode(buffer, resized)
-	} else if resp.Header.Get("content-type") == "image/gif" {
-		err = gif.Encode(buffer, resized, nil)
-	} else if resp.Header.Get("content-type") == "image/jpeg" {
-		err = jpeg.Encode(buffer, resized, nil)
-	}
-	if err != nil {
-		return []byte{}, fmt.Errorf("could not encode image from url: %s", resp.Request.URL)
-	}
-
-	return buffer.Bytes(), nil
-}
 
 func IsSupportedThumbnail(contentType string) bool {
 	for _, supportedType := range supportedThumbnails {

--- a/pkg/thumbnail/thumbnail.go
+++ b/pkg/thumbnail/thumbnail.go
@@ -2,6 +2,7 @@ package thumbnail
 
 import (
 	"github.com/Chatterino/api/pkg/config"
+	"github.com/Chatterino/api/pkg/utils"
 )
 
 var (
@@ -11,14 +12,8 @@ var (
 	cfg config.APIConfig
 )
 
-func IsSupportedThumbnail(contentType string) bool {
-	for _, supportedType := range supportedThumbnails {
-		if contentType == supportedType {
-			return true
-		}
-	}
-
-	return false
+func IsSupportedThumbnailType(contentType string) bool {
+	return utils.Contains(supportedThumbnails, contentType)
 }
 
 func IsAnimatedThumbnailType(contentType string) bool {

--- a/pkg/thumbnail/thumbnail_unix.go
+++ b/pkg/thumbnail/thumbnail_unix.go
@@ -8,16 +8,26 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/Chatterino/api/pkg/config"
+
+	vips "github.com/davidbyttow/govips/v2/vips"
 	"github.com/discord/lilliput"
 )
 
-var (
-	encodeOptions = map[string]map[int]int{
-		".jpeg": {lilliput.JpegQuality: 85},
-		".png":  {lilliput.PngCompression: 7},
-		".webp": {lilliput.WebpQuality: 85},
-	}
-)
+var encodeOptions = map[string]map[int]int{
+	".jpeg": {lilliput.JpegQuality: 85},
+	".png":  {lilliput.PngCompression: 7},
+	".webp": {lilliput.WebpQuality: 85},
+}
+
+func InitializeConfig(passedCfg config.APIConfig) {
+	cfg = passedCfg
+	vips.Startup(nil)
+}
+
+func Shutdown() {
+	vips.Shutdown()
+}
 
 func BuildAnimatedThumbnail(inputBuf []byte, resp *http.Response) ([]byte, error) {
 	// decoder wants []byte, so read the whole file into a buffer
@@ -95,4 +105,37 @@ func BuildAnimatedThumbnail(inputBuf []byte, resp *http.Response) ([]byte, error
 	}
 
 	return outputImg, nil
+}
+
+func BuildStaticThumbnail(inputBuf []byte, resp *http.Response) ([]byte, error) {
+	image, err := vips.NewImageFromBuffer(inputBuf)
+
+	// govips has the height & width values in int, which means we're converting uint to int.
+	maxThumbnailSize := int(cfg.MaxThumbnailSize)
+
+	// Only resize if the original image has bigger dimensions than maxThumbnailSize
+	if image.Width() <= maxThumbnailSize && image.Height() <= maxThumbnailSize {
+		// We don't need to resize image nor does it need to be passed through govips.
+		return inputBuf, nil
+	}
+
+	importParams := vips.NewImportParams()
+
+	if err != nil {
+		return []byte{}, fmt.Errorf("could not load image from url: %s", resp.Request.URL)
+	}
+
+	image, err = vips.LoadThumbnailFromBuffer(inputBuf, maxThumbnailSize, maxThumbnailSize, vips.InterestingNone, vips.SizeDown, importParams)
+
+	if err != nil {
+		fmt.Println(err)
+		return []byte{}, fmt.Errorf("could not transform image from url: %s", resp.Request.URL)
+	}
+
+	outputBuf, _, err := image.ExportNative()
+	if err != nil {
+		return []byte{}, fmt.Errorf("could not export image from url: %s", resp.Request.URL)
+	}
+
+	return outputBuf, nil
 }

--- a/pkg/thumbnail/thumbnail_windows.go
+++ b/pkg/thumbnail/thumbnail_windows.go
@@ -6,9 +6,26 @@ package thumbnail
 import (
 	"errors"
 	"net/http"
+
+	"github.com/Chatterino/api/pkg/config"
 )
+
+func InitializeConfig(passedCfg config.APIConfig) {
+	cfg = passedCfg
+}
+
+func Shutdown() {
+	// Nothing to shut down on Windows
+}
 
 func BuildAnimatedThumbnail(inputBuf []byte, resp *http.Response) ([]byte, error) {
 	// Since the lilliput library currently does not support Windows, we error out early and fall back to the static thumbnail generation
 	return nil, errors.New("cannot build animated thumbnails on windows")
+}
+
+func BuildStaticThumbnail(inputBuf []byte, resp *http.Response) ([]byte, error) {
+	// govips can run on Windows with the proper setup. If you would like to contribute Windows
+	// support, see https://github.com/davidbyttow/govips#windows and open a PR at
+	// https://github.com/Chatterino/api/pulls.
+	return nil, errors.New("cannot build static thumbnails on windows")
 }


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description
This PR fixes #336.

[libvips](https://github.com/libvips/libvips) is a powerful image processing library in C and [govips](https://github.com/davidbyttow/govips) provides Go bindings for most of its functions. #312 intends to replace lilliput with govips and the library looks promising to be useful when attacking other issues as well (#259, #347, and #363, to name a few), I decided implement this feature with it as well.
Thus, this PR can be seen as a first foray into using govips with a relatively simple and self-contained feature. This also means we can drop the `nfnt/resize` dependency.
Other than what @KararTY reported in #312, the `libvips` and `libvips-dev` packages in the Ubuntu 22.04 default repositories were sufficient for me to build this branch.

Since I have no way to way to test or develop this on Windows, this feature is limited to Linux. (But this is where I suspect the vast majority of usage to happen anyhow.)

## Future Opportunities
As described above, I believe libvips/govips to be helpful in attacking multiple current and future issues. Most notably, if libvips/govips proves viable, #312 may allow us to serve animated thumbnails at a manageable memory cost and replace lilliput altogether.

# Testing
When testing on different branches with the same link (e.g. `https://files.catbox.moe/8c5ref.jpeg`, courtesy of #336), make sure to either clear your cache or reupload the image elsewhere to circumvent caching.

