### PR TITLE
feat: Enable static thumbnail generation on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,8 +40,8 @@ jobs:
             Invoke-WebRequest -Uri https://github.com/libvips/build-win64-mxe/releases/download/v8.13.2/vips-dev-w64-web-8.13.2-static.zip -OutFile .\vips-dev.zip
             Expand-Archive -Path .\vips-dev.zip -DestinationPath .\
             $env:VIPS_PATH=$(Resolve-Path ".\vips-dev-8.13" | select -ExpandProperty Path)
-            $env:PKG_CONFIG_PATH += %VIPS_PATH%\lib\pkgconfig
-            $env:Path += %VIPS_PATH%\bin
+            $env:PKG_CONFIG_PATH += "%VIPS_PATH%\lib\pkgconfig"
+            $env:Path += ";%VIPS_PATH%\bin"
         shell: powershell
 
       - name: Get Go dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,17 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: brew install vips
 
+      - name: Get external dependencies (Windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          choco upgrade -y pkgconfiglite
+          Invoke-WebRequest -Uri https://github.com/libvips/build-win64-mxe/releases/download/v8.13.2/vips-dev-w64-web-8.13.2-static.zip -OutFile .\vips-dev.zip
+          Expand-Archive -Path .\vips-dev.zip -DestinationPath .\
+          $env:VIPS_PATH=$(Resolve-Path ".\vips-dev-8.13" | select -ExpandProperty Path)
+          $env:PKG_CONFIG_PATH += %VIPS_PATH%\lib\pkgconfig
+          $env:Path += %VIPS_PATH%\bin
+        shell: powershell
+
       - name: Get Go dependencies
         run: |
           go get -v -t -d ./...

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,9 +39,10 @@ jobs:
             choco upgrade -y pkgconfiglite
             Invoke-WebRequest -Uri https://github.com/libvips/build-win64-mxe/releases/download/v8.13.2/vips-dev-w64-web-8.13.2-static.zip -OutFile .\vips-dev.zip
             Expand-Archive -Path .\vips-dev.zip -DestinationPath .\
-            [System.Environment]::SetEnvironmentVariable('VIPS_PATH', $(Resolve-Path ".\vips-dev-8.13" | select -ExpandProperty Path), [System.EnvironmentVariableTarget]::User)
-            [System.Environment]::SetEnvironmentVariable('PKG_CONFIG_PATH', "$($env:VIPS_PATH)\lib\pkgconfig", [System.EnvironmentVariableTarget]::User)
-            [System.Environment]::SetEnvironmentVariable('Path', $env:Path + ";$($env:VIPS_PATH)\bin", [System.EnvironmentVariableTarget]::User)
+            $env:VIPS_PATH=$(Resolve-Path ".\vips-dev-8.13" | select -ExpandProperty Path)
+            "VIPS_PATH=$(Resolve-Path ".\vips-dev-8.13" | select -ExpandProperty Path)" >> $env:GITHUB_ENV
+            "PKG_CONFIG_PATH=$env:VIPS_PATH/lib/pkgconfig" >> $env:GITHUB_ENV
+            "$VIPS_PATH/bin" >> $env:GITHUB_PATH
 
       - name: Get Go dependencies
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,8 +41,8 @@ jobs:
             Expand-Archive -Path .\vips-dev.zip -DestinationPath .\
             $env:VIPS_PATH=$(Resolve-Path ".\vips-dev-8.13" | select -ExpandProperty Path)
             "VIPS_PATH=$(Resolve-Path ".\vips-dev-8.13" | select -ExpandProperty Path)" >> $env:GITHUB_ENV
-            "PKG_CONFIG_PATH=$env:VIPS_PATH/lib/pkgconfig" >> $env:GITHUB_ENV
-            "$VIPS_PATH/bin" >> $env:GITHUB_PATH
+            "PKG_CONFIG_PATH=$env:VIPS_PATH\lib\pkgconfig" >> $env:GITHUB_ENV
+            "$env:VIPS_PATH\bin" >> $env:GITHUB_PATH
 
       - name: Get Go dependencies
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,11 +40,8 @@ jobs:
             Invoke-WebRequest -Uri https://github.com/libvips/build-win64-mxe/releases/download/v8.13.2/vips-dev-w64-web-8.13.2-static.zip -OutFile .\vips-dev.zip
             Expand-Archive -Path .\vips-dev.zip -DestinationPath .\
             $env:VIPS_PATH=$(Resolve-Path ".\vips-dev-8.13" | select -ExpandProperty Path)
-            echo $env:VIPS_PATH
-            $env:PKG_CONFIG_PATH += ";$($env:VIPS_PATH)\lib\pkgconfig"
-            echo $env:PKG_CONFIG_PATH
+            $env:PKG_CONFIG_PATH = "$($env:VIPS_PATH)\lib\pkgconfig"
             $env:Path += ";$($env:VIPS_PATH)\bin"
-            echo $(vips)
 
       - name: Get Go dependencies
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,12 +36,12 @@ jobs:
       - name: Get external dependencies (Windows)
         if: matrix.os == 'windows-latest'
         run: |
-          choco upgrade -y pkgconfiglite
-          Invoke-WebRequest -Uri https://github.com/libvips/build-win64-mxe/releases/download/v8.13.2/vips-dev-w64-web-8.13.2-static.zip -OutFile .\vips-dev.zip
-          Expand-Archive -Path .\vips-dev.zip -DestinationPath .\
-          $env:VIPS_PATH=$(Resolve-Path ".\vips-dev-8.13" | select -ExpandProperty Path)
-          $env:PKG_CONFIG_PATH += %VIPS_PATH%\lib\pkgconfig
-          $env:Path += %VIPS_PATH%\bin
+            choco upgrade -y pkgconfiglite
+            Invoke-WebRequest -Uri https://github.com/libvips/build-win64-mxe/releases/download/v8.13.2/vips-dev-w64-web-8.13.2-static.zip -OutFile .\vips-dev.zip
+            Expand-Archive -Path .\vips-dev.zip -DestinationPath .\
+            $env:VIPS_PATH=$(Resolve-Path ".\vips-dev-8.13" | select -ExpandProperty Path)
+            $env:PKG_CONFIG_PATH += %VIPS_PATH%\lib\pkgconfig
+            $env:Path += %VIPS_PATH%\bin
         shell: powershell
 
       - name: Get Go dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,8 +40,8 @@ jobs:
             Invoke-WebRequest -Uri https://github.com/libvips/build-win64-mxe/releases/download/v8.13.2/vips-dev-w64-web-8.13.2-static.zip -OutFile .\vips-dev.zip
             Expand-Archive -Path .\vips-dev.zip -DestinationPath .\
             $env:VIPS_PATH=$(Resolve-Path ".\vips-dev-8.13" | select -ExpandProperty Path)
-            $env:PKG_CONFIG_PATH += "%VIPS_PATH%\lib\pkgconfig"
-            $env:Path += ";%VIPS_PATH%\bin"
+            $env:PKG_CONFIG_PATH += ";$($env:VIPS_PATH)\lib\pkgconfig"
+            $env:Path += ";$($env:VIPS_PATH)\bin"
         shell: powershell
 
       - name: Get Go dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,9 +39,9 @@ jobs:
             choco upgrade -y pkgconfiglite
             Invoke-WebRequest -Uri https://github.com/libvips/build-win64-mxe/releases/download/v8.13.2/vips-dev-w64-web-8.13.2-static.zip -OutFile .\vips-dev.zip
             Expand-Archive -Path .\vips-dev.zip -DestinationPath .\
-            $env:VIPS_PATH=$(Resolve-Path ".\vips-dev-8.13" | select -ExpandProperty Path)
-            $env:PKG_CONFIG_PATH = "$($env:VIPS_PATH)\lib\pkgconfig"
-            $env:Path += ";$($env:VIPS_PATH)\bin"
+            [System.Environment]::SetEnvironmentVariable('VIPS_PATH', $(Resolve-Path ".\vips-dev-8.13" | select -ExpandProperty Path), [System.EnvironmentVariableTarget]::User)
+            [System.Environment]::SetEnvironmentVariable('PKG_CONFIG_PATH', "$($env:VIPS_PATH)\lib\pkgconfig", [System.EnvironmentVariableTarget]::User)
+            [System.Environment]::SetEnvironmentVariable('Path', $env:Path + ";$($env:VIPS_PATH)\bin", [System.EnvironmentVariableTarget]::User)
 
       - name: Get Go dependencies
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,9 +40,11 @@ jobs:
             Invoke-WebRequest -Uri https://github.com/libvips/build-win64-mxe/releases/download/v8.13.2/vips-dev-w64-web-8.13.2-static.zip -OutFile .\vips-dev.zip
             Expand-Archive -Path .\vips-dev.zip -DestinationPath .\
             $env:VIPS_PATH=$(Resolve-Path ".\vips-dev-8.13" | select -ExpandProperty Path)
+            echo $env:VIPS_PATH
             $env:PKG_CONFIG_PATH += ";$($env:VIPS_PATH)\lib\pkgconfig"
+            echo $env:PKG_CONFIG_PATH
             $env:Path += ";$($env:VIPS_PATH)\bin"
-        shell: powershell
+            echo $(vips)
 
       - name: Get Go dependencies
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Breaking: Go version 1.17 is now the minimum required version to build this. (#292)
-- Breaking: Thumbnail generation now requires libvips. See [docs/build.md](./docs/build.md) for prerequisite instructions. (#366)
+- Breaking: Thumbnail generation now requires libvips. See [docs/build.md](./docs/build.md) for prerequisite instructions. (#366, #369)
 - Breaking: Resolver caches are now stored in PostgreSQL. See [docs/build.md](./docs/build.md) for prerequisite instructions. (#271)
 - YouTube: Added support for 'YouTube shorts' URLs. (#299)
 - Fix: SevenTV emotes now resolve correctly. (#281, #288, #307)

--- a/docs/build.md
+++ b/docs/build.md
@@ -10,7 +10,7 @@
 
    For Windows when getting the [Windows binaries](https://github.com/libvips/build-win64-mxe/releases/latest) from the libvips link above make sure to get the ones suffixed with "-static".
    Install pkg-config via choco `choco upgrade -y pkgconfiglite` and setup the following environment variables:
-   `VIPS_PATH` to the directory where vips binaries are downloaded and extracted,
+   `VIPS_PATH` to the directory where vips-dev is downloaded and extracted,
    `PKG_CONFIG_PATH` to `%VIPS_PATH%\lib\pkgconfig`
    and append `%VIPS_PATH%\bin` to your `Path` environment variable.
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -3,9 +3,16 @@
 ## Prerequisites
 
 1. Resolved links are stored in PostgreSQL, so you must have PostgreSQL installed and accessible for the user running the API. For Ubuntu, you would install it with `sudo apt install postgresql`, create a DB user for your system user (`sudo -upostgres createuser pajlada`), then create a db for the api (`sudo -upostgres createdb chatterino-api --owner pajlada`). Make sure to edit `dsn` in your [configuration](./config.md). Example, using the details above, `dsn:"host=/var/run/postgresql user=pajlada database=chatterino-api"`.
-2. You must have [`libvips`](https://github.com/libvips/libvips) >=8.12.0 installed for thumbnail generation. (Linux-exclusive)
+2. You must have [`libvips`](https://github.com/libvips/libvips) >=8.12.0 installed for thumbnail generation.
+
    On Ubuntu 22.04, this can be done with `sudo apt install libvips libvips-dev`.
    Different distros or releases may require adding a PPA or building and installing from source.
+
+   For Windows when getting the [Windows binaries](https://github.com/libvips/build-win64-mxe/releases/latest) from the libvips link above make sure to get the ones suffixed with "-static".
+   Install pkg-config via choco `choco upgrade -y pkgconfiglite` and setup the following environment variables:
+   `VIPS_PATH` to the directory where vips binaries are downloaded and extracted,
+   `PKG_CONFIG_PATH` to `%VIPS_PATH%\lib\pkgconfig`
+   and append `%VIPS_PATH%\bin` to your `Path` environment variable.
 
 ## Build
 

--- a/pkg/thumbnail/thumbnail.go
+++ b/pkg/thumbnail/thumbnail.go
@@ -1,8 +1,12 @@
 package thumbnail
 
 import (
+	"fmt"
+	"net/http"
+
 	"github.com/Chatterino/api/pkg/config"
 	"github.com/Chatterino/api/pkg/utils"
+	vips "github.com/davidbyttow/govips/v2/vips"
 )
 
 var (
@@ -18,4 +22,37 @@ func IsSupportedThumbnailType(contentType string) bool {
 
 func IsAnimatedThumbnailType(contentType string) bool {
 	return utils.Contains(animatedThumbnails, contentType)
+}
+
+func BuildStaticThumbnail(inputBuf []byte, resp *http.Response) ([]byte, error) {
+	image, err := vips.NewImageFromBuffer(inputBuf)
+
+	// govips has the height & width values in int, which means we're converting uint to int.
+	maxThumbnailSize := int(cfg.MaxThumbnailSize)
+
+	// Only resize if the original image has bigger dimensions than maxThumbnailSize
+	if image.Width() <= maxThumbnailSize && image.Height() <= maxThumbnailSize {
+		// We don't need to resize image nor does it need to be passed through govips.
+		return inputBuf, nil
+	}
+
+	importParams := vips.NewImportParams()
+
+	if err != nil {
+		return []byte{}, fmt.Errorf("could not load image from url: %s", resp.Request.URL)
+	}
+
+	image, err = vips.LoadThumbnailFromBuffer(inputBuf, maxThumbnailSize, maxThumbnailSize, vips.InterestingNone, vips.SizeDown, importParams)
+
+	if err != nil {
+		fmt.Println(err)
+		return []byte{}, fmt.Errorf("could not transform image from url: %s", resp.Request.URL)
+	}
+
+	outputBuf, _, err := image.ExportNative()
+	if err != nil {
+		return []byte{}, fmt.Errorf("could not export image from url: %s", resp.Request.URL)
+	}
+
+	return outputBuf, nil
 }

--- a/pkg/thumbnail/thumbnail.go
+++ b/pkg/thumbnail/thumbnail.go
@@ -24,6 +24,15 @@ func IsAnimatedThumbnailType(contentType string) bool {
 	return utils.Contains(animatedThumbnails, contentType)
 }
 
+func InitializeConfig(passedCfg config.APIConfig) {
+	cfg = passedCfg
+	vips.Startup(nil)
+}
+
+func Shutdown() {
+	vips.Shutdown()
+}
+
 func BuildStaticThumbnail(inputBuf []byte, resp *http.Response) ([]byte, error) {
 	image, err := vips.NewImageFromBuffer(inputBuf)
 

--- a/pkg/thumbnail/thumbnail_unix.go
+++ b/pkg/thumbnail/thumbnail_unix.go
@@ -8,8 +8,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/Chatterino/api/pkg/config"
-
 	"github.com/discord/lilliput"
 )
 
@@ -17,15 +15,6 @@ var encodeOptions = map[string]map[int]int{
 	".jpeg": {lilliput.JpegQuality: 85},
 	".png":  {lilliput.PngCompression: 7},
 	".webp": {lilliput.WebpQuality: 85},
-}
-
-func InitializeConfig(passedCfg config.APIConfig) {
-	cfg = passedCfg
-	vips.Startup(nil)
-}
-
-func Shutdown() {
-	vips.Shutdown()
 }
 
 func BuildAnimatedThumbnail(inputBuf []byte, resp *http.Response) ([]byte, error) {

--- a/pkg/thumbnail/thumbnail_unix.go
+++ b/pkg/thumbnail/thumbnail_unix.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/Chatterino/api/pkg/config"
 
-	vips "github.com/davidbyttow/govips/v2/vips"
 	"github.com/discord/lilliput"
 )
 
@@ -105,37 +104,4 @@ func BuildAnimatedThumbnail(inputBuf []byte, resp *http.Response) ([]byte, error
 	}
 
 	return outputImg, nil
-}
-
-func BuildStaticThumbnail(inputBuf []byte, resp *http.Response) ([]byte, error) {
-	image, err := vips.NewImageFromBuffer(inputBuf)
-
-	// govips has the height & width values in int, which means we're converting uint to int.
-	maxThumbnailSize := int(cfg.MaxThumbnailSize)
-
-	// Only resize if the original image has bigger dimensions than maxThumbnailSize
-	if image.Width() <= maxThumbnailSize && image.Height() <= maxThumbnailSize {
-		// We don't need to resize image nor does it need to be passed through govips.
-		return inputBuf, nil
-	}
-
-	importParams := vips.NewImportParams()
-
-	if err != nil {
-		return []byte{}, fmt.Errorf("could not load image from url: %s", resp.Request.URL)
-	}
-
-	image, err = vips.LoadThumbnailFromBuffer(inputBuf, maxThumbnailSize, maxThumbnailSize, vips.InterestingNone, vips.SizeDown, importParams)
-
-	if err != nil {
-		fmt.Println(err)
-		return []byte{}, fmt.Errorf("could not transform image from url: %s", resp.Request.URL)
-	}
-
-	outputBuf, _, err := image.ExportNative()
-	if err != nil {
-		return []byte{}, fmt.Errorf("could not export image from url: %s", resp.Request.URL)
-	}
-
-	return outputBuf, nil
 }

--- a/pkg/thumbnail/thumbnail_windows.go
+++ b/pkg/thumbnail/thumbnail_windows.go
@@ -6,17 +6,7 @@ package thumbnail
 import (
 	"errors"
 	"net/http"
-
-	"github.com/Chatterino/api/pkg/config"
 )
-
-func InitializeConfig(passedCfg config.APIConfig) {
-	cfg = passedCfg
-}
-
-func Shutdown() {
-	// Nothing to shut down on Windows
-}
 
 func BuildAnimatedThumbnail(inputBuf []byte, resp *http.Response) ([]byte, error) {
 	// Since the lilliput library currently does not support Windows, we error out early and fall back to the static thumbnail generation

--- a/pkg/thumbnail/thumbnail_windows.go
+++ b/pkg/thumbnail/thumbnail_windows.go
@@ -22,10 +22,3 @@ func BuildAnimatedThumbnail(inputBuf []byte, resp *http.Response) ([]byte, error
 	// Since the lilliput library currently does not support Windows, we error out early and fall back to the static thumbnail generation
 	return nil, errors.New("cannot build animated thumbnails on windows")
 }
-
-func BuildStaticThumbnail(inputBuf []byte, resp *http.Response) ([]byte, error) {
-	// govips can run on Windows with the proper setup. If you would like to contribute Windows
-	// support, see https://github.com/davidbyttow/govips#windows and open a PR at
-	// https://github.com/Chatterino/api/pulls.
-	return nil, errors.New("cannot build static thumbnails on windows")
-}


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

With this PR, I move @leon-richardt bespoke code from `thumbnail_unix.go` to `thumbnail.go` now that I've tested that this works just fine on Windows as well. (#312 should hopefully, eventually, eliminate `thumbnail_unix.go` completely if this PR goes well)

I've also updated the GitHub Windows workflow, with @33kk's help, to install a hardcoded version of libvips. Why hardcoded? Because I could not figure out how to download the latest release of anything on GitHub without resorting to JSON parsing, and if you want to tear your hair out dealing with that manually by writing Powershell then that's very humbling.

In any case, 8.13.2 should be sufficient for Windows for now. People who host chatterino/api and/or build from source can use updated version without issue, unless there's breaking changes of course.

The build prerequisites snippet addition basically describes the GitHub workflow, and you do need to follow it. Doesn't matter if you are just building or just hosting Chatterino API.

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
