### PR TITLE
fix: Don't return inputBuf if input is of type PDF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Breaking: Go version 1.17 is now the minimum required version to build this. (#292)
 - Breaking: Thumbnail generation now requires libvips. See [docs/build.md](./docs/build.md) for prerequisite instructions. (#366, #369)
 - Breaking: Resolver caches are now stored in PostgreSQL. See [docs/build.md](./docs/build.md) for prerequisite instructions. (#271)
-- PDF: Generate customized tooltips for PDF files. (#374)
+- PDF: Generate customized tooltips for PDF files. (#374, #377)
 - Twitter: Generate thumbnails with all images of a tweet. (#373)
 - YouTube: Added support for 'YouTube shorts' URLs. (#299)
 - Fix: SevenTV emotes now resolve correctly. (#281, #288, #307)


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Related to #374.

I have a maxThumbnailSize that is very high, which means that libvips default sizing for PDFs is within the limit, which is allowing this `if` check to return early:
https://github.com/Chatterino/api/blob/67a1371ef95e532dbff7c66da2acd67b96de84b0/pkg/thumbnail/thumbnail.go#L53-L57

That early return of the inputBuf makes this happen:
![image](https://user-images.githubusercontent.com/13697809/196557340-92f61e85-9bf7-44ca-acdd-5d75a33333f0.png)

Which definitely isn't intentional.

This PR adds an additional conditional to the `if` check and moves some things around to make the `format` variable work without crashing if image errors out. (Calling image.Format() when previous `image, err := ...` fails crashes the software, I learned.)

<details>
  <summary>Images</summary>

Before:
![image](https://user-images.githubusercontent.com/13697809/196558237-f28b2feb-3962-4246-80b6-50d6876568e8.png)
After:
![image](https://user-images.githubusercontent.com/13697809/196558664-7b41a1e0-e6ad-43ad-90f2-d142bcbf0ec1.png)

And yes, I have thumbnails set to size 900 in Chatterino.
</details>