### PR TITLE
fix: Add checksums for Windows Github Action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Get external dependencies (Windows)
         if: matrix.os == 'windows-latest'
         run: |
-            choco upgrade -y pkgconfiglite
+            choco upgrade -y pkgconfiglite --download-checksum 2038c49d23b5ca19e2218ca89f06df18fe6d870b4c6b54c0498548ef88771f6f --download-checksum-type sha256
             Invoke-WebRequest -Uri https://github.com/libvips/build-win64-mxe/releases/download/v8.13.2/vips-dev-w64-web-8.13.2-static.zip -OutFile .\vips-dev.zip
             Expand-Archive -Path .\vips-dev.zip -DestinationPath .\
             $env:VIPS_PATH=$(Resolve-Path ".\vips-dev-8.13" | select -ExpandProperty Path)


### PR DESCRIPTION
Pull request checklist:

- [ ] `CHANGELOG.md` was updated, if applicable

# Description

Chocolatey wants a checksum to be provided, but since package is older than ancient it was never added to Chocolatey. No idea why it sometimes works though.

This fix is from https://github.com/chocolatey/choco/issues/910 and subsequently https://github.com/chocolatey/choco/issues/112#issue-58511395.

SHA-256 Checksum from VirusTotal https://www.virustotal.com/gui/file/2038c49d23b5ca19e2218ca89f06df18fe6d870b4c6b54c0498548ef88771f6f/details

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
