### PR TITLE
Ignore websites based on their hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - PDF: Generate customized tooltips for PDF files. (#374, #377)
 - Twitter: Generate thumbnails with all images of a tweet. (#373)
 - YouTube: Added support for 'YouTube shorts' URLs. (#299)
+- Minor: Add ability to opt out hostnames from the API. (#405)
 - Fix: SevenTV emotes now resolve correctly. (#281, #288, #307)
 - Fix: YouTube videos are no longer resolved as channels. (#284)
 - Fix: Default resolver no longer crashes when provided url is broken. (#310)

--- a/internal/resolvers/default/initialize.go
+++ b/internal/resolvers/default/initialize.go
@@ -26,7 +26,10 @@ const (
 var defaultTooltip = template.Must(template.New("default_tooltip").Parse(defaultTooltipString))
 
 func Initialize(ctx context.Context, cfg config.APIConfig, pool db.Pool, router *chi.Mux, helixClient *helix.Client) {
-	defaultLinkResolver := New(ctx, cfg, pool, helixClient)
+	// Ignored hosts can be added here at request of the hoster
+	ignoredHosts := map[string]struct{}{}
+
+	defaultLinkResolver := New(ctx, cfg, pool, helixClient, ignoredHosts)
 
 	imageCached := stampede.Handler(256, 2*time.Second)
 	generatedValuesCached := stampede.Handler(256, 2*time.Second)

--- a/internal/resolvers/default/link_resolver_test.go
+++ b/internal/resolvers/default/link_resolver_test.go
@@ -64,7 +64,11 @@ func TestLinkResolver(t *testing.T) {
 
 	router := chi.NewRouter()
 
-	r := New(ctx, cfg, pool, nil)
+	ignoredHosts := map[string]struct{}{
+		"ignoredhost.com": {},
+	}
+
+	r := New(ctx, cfg, pool, nil, ignoredHosts)
 
 	router.Get("/link_resolver/{url}", r.HandleRequest)
 	router.Get("/thumbnail/{url}", r.HandleThumbnailRequest)
@@ -198,6 +202,24 @@ func TestLinkResolver(t *testing.T) {
 					Status:  http.StatusBadRequest,
 					Link:    "",
 					Message: `Could not fetch link info: Invalid URL`,
+				},
+			},
+			{
+				inputReq:     newLinkResolverRequest(t, ctx, "GET", "https://ignoredhost.com/forsen", nil),
+				inputLinkKey: ts.URL,
+				expected: resolver.Response{
+					Status:  http.StatusForbidden,
+					Link:    "",
+					Message: `Link forbidden`,
+				},
+			},
+			{
+				inputReq:     newLinkResolverRequest(t, ctx, "GET", "https://IgnoredHost.com/forsen", nil),
+				inputLinkKey: ts.URL,
+				expected: resolver.Response{
+					Status:  http.StatusForbidden,
+					Link:    "",
+					Message: `Link forbidden`,
 				},
 			},
 		}

--- a/pkg/resolver/static_responses.go
+++ b/pkg/resolver/static_responses.go
@@ -17,6 +17,8 @@ var (
 
 	InvalidURLBytes = []byte(`{"status":400,"message":"Could not fetch link info: Invalid URL"}`)
 
+	ForbiddenURLBytes = []byte(`{"status":403,"message":"Link forbidden"}`)
+
 	// Dynamically created based on config
 	ResponseTooLarge []byte
 )
@@ -31,6 +33,12 @@ func WriteInvalidURL(w http.ResponseWriter) (int, error) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusBadRequest)
 	return w.Write(InvalidURLBytes)
+}
+
+func WriteForbiddenURL(w http.ResponseWriter) (int, error) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusForbidden)
+	return w.Write(ForbiddenURLBytes)
 }
 
 func InitializeStaticResponses(ctx context.Context, cfg config.APIConfig) {


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Allow hosters to opt out of the Chatterino Link Resolver server-side

Not every hoster has the ability or resources to block our link resolver - this provides a simple way to block entire hosts.
Validation of ownership will be made manually when entries are added to the `ignoredHosts` map

What it looks like in Chatterino:
![image](https://user-images.githubusercontent.com/962989/206903882-14e73db5-500f-4bbc-88c9-05276a9a4e3d.png)


<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
