### PR TITLE
Add HTTP Caching headers to links and thumbnails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 - Dev: Resolve imgur.io links. (#365)
 - Dev: Don't use `stampede` for link resolver links. (#394)
 - Dev: Update to Twitter's v2 API. (#414)
-- Dev: Add HTTP Caching headers
+- Dev: Add HTTP Caching headers. (#417)
 
 ## 1.2.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Dev: Resolve imgur.io links. (#365)
 - Dev: Don't use `stampede` for link resolver links. (#394)
 - Dev: Update to Twitter's v2 API. (#414)
+- Dev: Add HTTP Caching headers
 
 ## 1.2.3
 

--- a/internal/resolvers/default/initialize.go
+++ b/internal/resolvers/default/initialize.go
@@ -35,6 +35,7 @@ func Initialize(ctx context.Context, cfg config.APIConfig, pool db.Pool, router 
 	imageCached := stampede.Handler(256, 2*time.Second)
 	generatedValuesCached := stampede.Handler(256, 2*time.Second)
 
+	// TODO: Make the max age headers be applied based on the resolved link's configured cache timer
 	router.With(cache.MaxAgeHeaders(time.Minute*10)).Get("/link_resolver/{url}", defaultLinkResolver.HandleRequest)
 	router.With(cache.MaxAgeHeaders(time.Minute*10), imageCached).Get("/thumbnail/{url}", defaultLinkResolver.HandleThumbnailRequest)
 	router.With(generatedValuesCached).Get("/generated/{url}", defaultLinkResolver.HandleGeneratedValueRequest)

--- a/internal/resolvers/default/initialize.go
+++ b/internal/resolvers/default/initialize.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/Chatterino/api/internal/db"
+	"github.com/Chatterino/api/pkg/cache"
 	"github.com/Chatterino/api/pkg/config"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/stampede"
@@ -34,7 +35,7 @@ func Initialize(ctx context.Context, cfg config.APIConfig, pool db.Pool, router 
 	imageCached := stampede.Handler(256, 2*time.Second)
 	generatedValuesCached := stampede.Handler(256, 2*time.Second)
 
-	router.Get("/link_resolver/{url}", defaultLinkResolver.HandleRequest)
-	router.With(imageCached).Get("/thumbnail/{url}", defaultLinkResolver.HandleThumbnailRequest)
+	router.With(cache.MaxAgeHeaders(time.Minute*10)).Get("/link_resolver/{url}", defaultLinkResolver.HandleRequest)
+	router.With(cache.MaxAgeHeaders(time.Minute*10), imageCached).Get("/thumbnail/{url}", defaultLinkResolver.HandleThumbnailRequest)
 	router.With(generatedValuesCached).Get("/generated/{url}", defaultLinkResolver.HandleGeneratedValueRequest)
 }

--- a/pkg/cache/middleware.go
+++ b/pkg/cache/middleware.go
@@ -1,0 +1,18 @@
+package cache
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// MaxAgeHeaders adds the Cache-Control: max-age=$TTL header to every response
+func MaxAgeHeaders(ttl time.Duration) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Add("Cache-Control", fmt.Sprintf("max-age=%.0f", ttl.Seconds()))
+			next.ServeHTTP(w, r)
+		})
+	}
+
+}

--- a/pkg/cache/middleware.go
+++ b/pkg/cache/middleware.go
@@ -14,5 +14,4 @@ func MaxAgeHeaders(ttl time.Duration) func(next http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 		})
 	}
-
 }


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Add `Cache-Control: max-age=600` headers to Link Resolver and Thumbnail requests in order to make Cloudflare cache the responses. Left the TTL hardcoded on purpose to not interfere with #410.
