### PR TITLE
Remove middleware that strips trailing slashes

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -118,9 +118,6 @@ func main() {
 
 	router := chi.NewRouter()
 
-	// Strip trailing slashes from API requests
-	router.Use(middleware.StripSlashes)
-
 	var helixUsernameCache cache.Cache
 
 	helixClient, err := twitchapiclient.New(ctx, cfg)


### PR DESCRIPTION
Pull request checklist:

- [ ] `CHANGELOG.md` was updated, if applicable

# Description

The middleware does not seem to do anything from my testing at least. It is harmful, since for example mobile tiktok links with trailing slashes are not matched to any routers.
Example: https://vm.tiktok.com/ZMY8my6vq/
