### PR TITLE
Add custom middleware to strip slashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Dev: Don't use `stampede` for link resolver links. (#394)
 - Dev: Update to Twitter's v2 API. (#414)
 - Dev: Add HTTP Caching headers. (#417)
+- Dev: Add custom middleware to strip trailing slashes. (#422)
 
 ## 1.2.3
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -148,7 +148,7 @@ func main() {
 func StripSlashes(next http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.Path
-                if len(path) > 1 && (path[len(path)-1] == '/' || path[len(path)-3:len(path)-1] == "%2F") {
+		if len(path) > 1 && (path[len(path)-1] == '/' || path[len(path)-3:len(path)-1] == "%2F") {
 			r.URL.Path = path[:len(path)-1]
 		}
 		next.ServeHTTP(w, r)

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -145,7 +145,8 @@ func main() {
 	listen(ctx, cfg.BindAddress, mountRouter(router, cfg, log), log)
 }
 
-// the middleware provided in chi has a bug, so a custom solution has to be used
+// StripSlashes strips slashes at the end of a request.
+// The StripSlashes middleware provided in chi has a bug, so a custom solution has to be used
 // TODO: can be switched to chi middleware,
 // if bug described in https://github.com/Chatterino/api/pull/422 is fixed
 func StripSlashes(next http.Handler) http.Handler {

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -145,10 +145,13 @@ func main() {
 	listen(ctx, cfg.BindAddress, mountRouter(router, cfg, log), log)
 }
 
+// the middleware provided in chi has a bug, so a custom solution has to be used
+// TODO: can be switched to chi middleware,
+// if bug described in https://github.com/Chatterino/api/pull/422 is fixed
 func StripSlashes(next http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.Path
-		if len(path) > 1 && (path[len(path)-1] == '/' || path[len(path)-3:len(path)-1] == "%2F") {
+		if len(path) > 1 && path[len(path)-1] == '/' {
 			r.URL.Path = path[:len(path)-1]
 		}
 		next.ServeHTTP(w, r)


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Heavily inspired by the middleware provided by chi. The new custom solution also strips url-encoded trailing slashes.
This for example fixes mobile tiktok links ( `https://vm.tiktok.com/ZMY8my6vq/` ), which are shared with a trailing slash by default. They didn't match to the link resolver router before the changes in this pr.

## EDIT

After some investigation, the true cause for this problem has been found. The middleware from chi uses the decoded URL to strip slashes. So it correctly strips both trailing "/" and trailing "%2F". It then uses the decoded URL to determine the correct handler for the route. Requests to `/link_resolver/{url}` now contain a URL that is not encoded anymore, and chi fails to find the proper handler. The new middleware fixes this by assigning the encoded URL to the correct parameter.