### PR TITLE
Add instant download warning

### DIFF
--- a/internal/resolvers/default/initialize.go
+++ b/internal/resolvers/default/initialize.go
@@ -19,7 +19,7 @@ const (
 <b>{{.Title}}</b><hr>
 {{end}}
 {{if .Description}}
-<span>{{.Description}}</span>
+<span>{{.Description}}</span><hr>
 {{end}}
 <b>URL:</b> {{.URL}}</div>
 {{ if .InstantDownload }}

--- a/internal/resolvers/default/initialize.go
+++ b/internal/resolvers/default/initialize.go
@@ -19,9 +19,12 @@ const (
 <b>{{.Title}}</b><hr>
 {{end}}
 {{if .Description}}
-<span>{{.Description}}</span><hr>
+<span>{{.Description}}</span>
 {{end}}
-<b>URL:</b> {{.URL}}</div>`
+<b>URL:</b> {{.URL}}</div>
+{{ if .InstantDownload }}
+<br><b><span style="color: red;">MIGHT DOWNLOAD INSTANTLY</span></b>
+{{end}}`
 )
 
 var defaultTooltip = template.Must(template.New("default_tooltip").Parse(defaultTooltipString))

--- a/internal/resolvers/default/link_loader.go
+++ b/internal/resolvers/default/link_loader.go
@@ -133,6 +133,11 @@ func (l *LinkLoader) Load(ctx context.Context, urlString string, r *http.Request
 	// Sanitize potential html values
 	data.Sanitize()
 
+	// Add instant download warning
+	if resp.Header.Get("Content-Type") == "application/octet-stream" || strings.Contains(resp.Header.Get("Content-Disposition"), "attachment") {
+		data.InstantDownload = true
+	}
+
 	var tooltip bytes.Buffer
 	if err := defaultTooltip.Execute(&tooltip, data); err != nil {
 		return utils.MarshalNoDur(&resolver.Response{

--- a/internal/resolvers/default/model.go
+++ b/internal/resolvers/default/model.go
@@ -16,10 +16,11 @@ type ContentTypeResolver interface {
 }
 
 type tooltipData struct {
-	URL         string
-	Title       string
-	Description string
-	ImageSrc    string
+	URL             string
+	Title           string
+	Description     string
+	ImageSrc        string
+	InstantDownload bool
 }
 
 func (d *tooltipData) Truncate() {


### PR DESCRIPTION
Pull request checklist:

- [ ] `CHANGELOG.md` was updated, if applicable

# Description
Add a red warning if a link might be downloaded instantly upon opening.
Detection is based on [this stackoverflow post](https://stackoverflow.com/questions/7389378/mp4-is-downloading-instead-of-playing), feel free to find a better source with more comprehensive checks.
