### PR TITLE
Add Media Resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - PDF: Generate customized tooltips for PDF files. (#374, #377)
 - Twitter: Generate thumbnails with all images of a tweet. (#373)
 - YouTube: Added support for 'YouTube shorts' URLs. (#299)
+- Media files: Generate tooltips for Video and Audio files. (#427)
 - Minor: Add ability to opt out hostnames from the API. (#405)
 - Fix: SevenTV emotes now resolve correctly. (#281, #288, #307)
 - Fix: YouTube videos are no longer resolved as channels. (#284)

--- a/internal/resolvers/default/link_resolver.go
+++ b/internal/resolvers/default/link_resolver.go
@@ -248,8 +248,10 @@ func New(ctx context.Context, cfg config.APIConfig, pool db.Pool, helixClient *h
 	youtube.Initialize(ctx, cfg, pool, &customResolvers)
 	seventv.Initialize(ctx, cfg, pool, &customResolvers)
 
-	contentTypeResolvers := []ContentTypeResolver{}
-	contentTypeResolvers = append(contentTypeResolvers, NewPDFResolver(cfg.BaseURL, cfg.MaxContentLength))
+	contentTypeResolvers := []ContentTypeResolver{
+		NewPDFResolver(cfg.BaseURL, cfg.MaxContentLength),
+		NewMediaResolver(cfg.BaseURL),
+	}
 
 	linkLoader := &LinkLoader{
 		baseURL:              cfg.BaseURL,

--- a/internal/resolvers/default/link_resolver.go
+++ b/internal/resolvers/default/link_resolver.go
@@ -248,6 +248,7 @@ func New(ctx context.Context, cfg config.APIConfig, pool db.Pool, helixClient *h
 	youtube.Initialize(ctx, cfg, pool, &customResolvers)
 	seventv.Initialize(ctx, cfg, pool, &customResolvers)
 
+	// The content type resolvers should match from most to least specific
 	contentTypeResolvers := []ContentTypeResolver{
 		NewPDFResolver(cfg.BaseURL, cfg.MaxContentLength),
 		NewMediaResolver(cfg.BaseURL),

--- a/internal/resolvers/default/media_resolver.go
+++ b/internal/resolvers/default/media_resolver.go
@@ -7,12 +7,10 @@ import (
 	"html/template"
 	"mime"
 	"net/http"
-	"net/url"
 	"strings"
 
 	"github.com/Chatterino/api/pkg/humanize"
 	"github.com/Chatterino/api/pkg/resolver"
-	"github.com/Chatterino/api/pkg/utils"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )
@@ -69,10 +67,9 @@ func (r *MediaResolver) Run(ctx context.Context, req *http.Request, resp *http.R
 
 	targetURL := resp.Request.URL.String()
 	response := &resolver.Response{
-		Status:    http.StatusOK,
-		Link:      targetURL,
-		Tooltip:   url.PathEscape(tooltip.String()),
-		Thumbnail: utils.FormatThumbnailURL(r.baseURL, req, targetURL),
+		Status:  http.StatusOK,
+		Link:    targetURL,
+		Tooltip: tooltip.String(),
 	}
 
 	return response, nil
@@ -101,6 +98,10 @@ func extensionFromMime(mimeType string) string {
 			return "wav"
 		case "mpeg":
 			return "mp3"
+		case "mp4":
+			return "mp4"
+		case "ogg":
+			return "ogg"
 		}
 	case "video":
 		switch s2 {
@@ -108,6 +109,10 @@ func extensionFromMime(mimeType string) string {
 			return "avi"
 		case "mp4":
 			return "mp4"
+		case "mpeg":
+			return "MPEG"
+		case "ogg":
+			return "OGG"
 		case "quicktime":
 			return "mov"
 		}

--- a/internal/resolvers/default/media_resolver.go
+++ b/internal/resolvers/default/media_resolver.go
@@ -43,8 +43,6 @@ func (r *MediaResolver) Check(ctx context.Context, contentType string) bool {
 }
 
 func (r *MediaResolver) Run(ctx context.Context, req *http.Request, resp *http.Response) (*resolver.Response, error) {
-	// log := logger.FromContext(ctx)
-
 	mimeType := resp.Header.Get("Content-Type")
 	spl := strings.Split(mimeType, "/")
 

--- a/internal/resolvers/default/media_resolver.go
+++ b/internal/resolvers/default/media_resolver.go
@@ -11,6 +11,8 @@ import (
 	"github.com/Chatterino/api/pkg/humanize"
 	"github.com/Chatterino/api/pkg/resolver"
 	"github.com/Chatterino/api/pkg/utils"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 const mediaTooltipTemplateString = `<div style="text-align: left;">
@@ -53,7 +55,7 @@ func (r *MediaResolver) Run(ctx context.Context, req *http.Request, resp *http.R
 	}
 
 	ttData := mediaTooltipData{
-		MediaType: strings.Title(spl[0]),
+		MediaType: cases.Title(language.English).String(spl[0]),
 		Extension: extensionFromMime(mimeType),
 		Size:      size,
 	}

--- a/internal/resolvers/default/media_resolver.go
+++ b/internal/resolvers/default/media_resolver.go
@@ -110,9 +110,9 @@ func extensionFromMime(mimeType string) string {
 		case "mp4":
 			return "mp4"
 		case "mpeg":
-			return "MPEG"
+			return "mpeg"
 		case "ogg":
-			return "OGG"
+			return "ogg"
 		case "quicktime":
 			return "mov"
 		}

--- a/internal/resolvers/default/media_resolver.go
+++ b/internal/resolvers/default/media_resolver.go
@@ -7,6 +7,7 @@ import (
 	"html/template"
 	"mime"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/Chatterino/api/pkg/humanize"
@@ -69,7 +70,7 @@ func (r *MediaResolver) Run(ctx context.Context, req *http.Request, resp *http.R
 	response := &resolver.Response{
 		Status:  http.StatusOK,
 		Link:    targetURL,
-		Tooltip: tooltip.String(),
+		Tooltip: url.PathEscape(tooltip.String()),
 	}
 
 	return response, nil

--- a/internal/resolvers/default/media_resolver.go
+++ b/internal/resolvers/default/media_resolver.go
@@ -1,0 +1,129 @@
+package defaultresolver
+
+import (
+	"bytes"
+	"context"
+	"html/template"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/Chatterino/api/pkg/humanize"
+	"github.com/Chatterino/api/pkg/resolver"
+	"github.com/Chatterino/api/pkg/utils"
+)
+
+const mediaTooltipTemplateString = `<div style="text-align: left;">
+<b>Media File</b>
+{{if .MediaType}}<br><b>Type:</b> {{.MediaType}}{{end}}
+{{if .Extension}}<br><b>Extension:</b> {{.Extension}}{{end}}
+{{if .Size}}<br><b>Size:</b> {{.Size}}{{end}}
+</div>
+`
+
+var mediaTooltipTemplate = template.Must(template.New("mediaTooltipTemplate").Parse(mediaTooltipTemplateString))
+
+type mediaTooltipData struct {
+	MediaType string
+	Extension string
+	Size      string
+}
+
+type MediaResolver struct {
+	baseURL string
+}
+
+func (r *MediaResolver) Check(ctx context.Context, contentType string) bool {
+	spl := strings.Split(contentType, "/")
+	switch spl[0] {
+	case "video", "audio", "application":
+		return true
+	}
+	return false
+}
+
+func (r *MediaResolver) Run(ctx context.Context, req *http.Request, resp *http.Response) (*resolver.Response, error) {
+	// log := logger.FromContext(ctx)
+
+	mimeType := resp.Header.Get("Content-Type")
+	spl := strings.Split(mimeType, "/")
+
+	size := ""
+	reportedSize := resp.ContentLength
+	if reportedSize > 0 {
+		size = humanize.Bytes(uint64(reportedSize))
+	}
+
+	ttData := mediaTooltipData{
+		MediaType: strings.Title(spl[0]),
+		Extension: extensionFromMime(mimeType),
+		Size:      size,
+	}
+
+	var tooltip bytes.Buffer
+	if err := mediaTooltipTemplate.Execute(&tooltip, ttData); err != nil {
+		return nil, err
+	}
+
+	targetURL := resp.Request.URL.String()
+	response := &resolver.Response{
+		Status:    http.StatusOK,
+		Link:      targetURL,
+		Tooltip:   url.PathEscape(tooltip.String()),
+		Thumbnail: utils.FormatThumbnailURL(r.baseURL, req, targetURL),
+	}
+
+	return response, nil
+}
+
+func (r *MediaResolver) Name() string {
+	return "MediaResolver"
+}
+
+func NewMediaResolver(baseURL string) *MediaResolver {
+	return &MediaResolver{
+		baseURL: baseURL,
+	}
+}
+
+func extensionFromMime(mimeType string) string {
+	spl := strings.Split(mimeType, "/")
+	if len(spl) < 2 {
+		return ""
+	}
+	s1, s2 := spl[0], spl[1]
+	switch s1 {
+	case "audio":
+		switch s2 {
+		case "wav", "x-wav":
+			return "wav"
+		default:
+			return "mp3"
+		}
+	case "video":
+		switch s2 {
+		case "avi":
+			return "avi"
+		case "quicktime":
+			return "mov"
+		default:
+			return "mp4"
+		}
+	case "application":
+		switch s2 {
+		case "json":
+			return "json"
+		case "x-gzip":
+			return "gz"
+		case "javascript", "x-javascript", "ecmascript":
+			return "js"
+		case "pdf":
+			return "pdf"
+		case "xml":
+			return "xml"
+		case "x-compressed", "x-zip-compressed", "zip":
+			return "zip"
+		}
+	}
+	return "Unknown"
+}

--- a/internal/resolvers/default/media_resolver_test.go
+++ b/internal/resolvers/default/media_resolver_test.go
@@ -51,12 +51,14 @@ func runMRTest(t *testing.T, contentType string, size int64, expectedType string
 		return
 	}
 
-	if !strings.Contains(res.Tooltip, expectedType) {
+	resUnescaped, err := url.PathUnescape(res.Tooltip)
+
+	if !strings.Contains(resUnescaped, expectedType) {
 		t.Errorf("Expected: %s, Got: %s", expectedType, res.Tooltip)
 	}
 
 	expectedSize := humanize.Bytes(uint64(size))
-	if size > 0 && !strings.Contains(res.Tooltip, expectedSize) {
+	if size > 0 && !strings.Contains(resUnescaped, expectedSize) {
 		t.Errorf("Expected: %s, Got: %s", expectedSize, res.Tooltip)
 	}
 }

--- a/internal/resolvers/default/media_resolver_test.go
+++ b/internal/resolvers/default/media_resolver_test.go
@@ -1,0 +1,62 @@
+package defaultresolver_test
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	defaultresolver "github.com/Chatterino/api/internal/resolvers/default"
+	"github.com/Chatterino/api/pkg/humanize"
+)
+
+func TestMediaResolver(t *testing.T) {
+	runMRTest(t, "video/mp4", 12345, "Video (MP4)")
+	runMRTest(t, "video/mpeg", 12345, "Video (MPEG)")
+	runMRTest(t, "video/ogg", 12345, "Video (OGG)")
+	runMRTest(t, "video/webm", 12345, "Video (WEBM)")
+	runMRTest(t, "video/x-msvideo", 12345, "Video (AVI)")
+	runMRTest(t, "video/nam", 12345, "Video (UNKNOWN)")
+
+	runMRTest(t, "audio/mpeg", 12345, "Audio (MP3)")
+	runMRTest(t, "audio/mp4", 12345, "Audio (MP4)")
+	runMRTest(t, "audio/ogg", 12345, "Audio (OGG)")
+	runMRTest(t, "audio/wav", 12345, "Audio (WAV)")
+
+	runMRTest(t, "audio/wav", 12345, "Audio (WAV)")
+}
+
+func runMRTest(t *testing.T, contentType string, size int64, expectedType string) {
+	mr := &defaultresolver.MediaResolver{}
+	httpRes := &http.Response{
+		Header: http.Header{
+			"Content-Type": []string{contentType},
+		},
+		ContentLength: size,
+		Request: &http.Request{
+			URL: &url.URL{},
+		},
+	}
+	if !mr.Check(context.Background(), contentType) {
+		if expectedType == "" {
+			return
+		}
+		t.Errorf("Expected MediaResolver to handle content type: %s", contentType)
+		return
+	}
+	res, err := mr.Run(context.Background(), nil, httpRes)
+	if err != nil {
+		t.Errorf("MediaResolver should never return an error: %v", err)
+		return
+	}
+
+	if !strings.Contains(res.Tooltip, expectedType) {
+		t.Errorf("Expected: %s, Got: %s", expectedType, res.Tooltip)
+	}
+
+	expectedSize := humanize.Bytes(uint64(size))
+	if size > 0 && !strings.Contains(res.Tooltip, expectedSize) {
+		t.Errorf("Expected: %s, Got: %s", expectedSize, res.Tooltip)
+	}
+}

--- a/internal/resolvers/default/media_resolver_test.go
+++ b/internal/resolvers/default/media_resolver_test.go
@@ -52,6 +52,10 @@ func runMRTest(t *testing.T, contentType string, size int64, expectedType string
 	}
 
 	resUnescaped, err := url.PathUnescape(res.Tooltip)
+	if err != nil {
+		t.Errorf("PathUnescape should never fail: %v", err)
+		return
+	}
 
 	if !strings.Contains(resUnescaped, expectedType) {
 		t.Errorf("Expected: %s, Got: %s", expectedType, res.Tooltip)

--- a/pkg/humanize/bytes.go
+++ b/pkg/humanize/bytes.go
@@ -1,0 +1,17 @@
+package humanize
+
+import "fmt"
+
+var bytesSteps = []string{"B", "KB", "MB", "GB"}
+
+func Bytes(n uint64) string {
+	div := float64(1000)
+	val := float64(n)
+	for _, step := range bytesSteps {
+		if val < 1000 {
+			return fmt.Sprintf("%.1f %s", val, step)
+		}
+		val /= div
+	}
+	return fmt.Sprintf("%.1f %s", val, "TB")
+}

--- a/pkg/humanize/bytes_test.go
+++ b/pkg/humanize/bytes_test.go
@@ -1,0 +1,34 @@
+package humanize_test
+
+import (
+	"testing"
+
+	"github.com/Chatterino/api/pkg/humanize"
+	qt "github.com/frankban/quicktest"
+)
+
+func TestBytes(t *testing.T) {
+	c := qt.New(t)
+	type testCase struct {
+		input    uint64
+		expected string
+	}
+	cases := []testCase{
+		{0, "0.0 B"},
+		{1, "1.0 B"},
+		{1000, "1.0 KB"},
+		{1001, "1.0 KB"},
+		{1501, "1.5 KB"},
+		{1234 * 1000, "1.2 MB"},
+		{1234 * 1000 * 1000, "1.2 GB"},
+		{1234 * 1000 * 1000 * 1000, "1.2 TB"},
+		{1234 * 1000 * 1000 * 1000 * 1000, "1234.0 TB"},
+	}
+
+	for _, tc := range cases {
+		c.Run("", func(c *qt.C) {
+			res := humanize.Bytes(tc.input)
+			c.Assert(res, qt.Equals, tc.expected)
+		})
+	}
+}


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Add Tooltip-only Resolver for previously unsupported Media files. Particularly useful for file uploaders that do not show the file extension.

![image](https://user-images.githubusercontent.com/17351521/215917859-ccda259e-f000-487a-b0ed-f8202818cd3f.png)


