### PR TITLE
Use 7TV V3 API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Minor: Added support for FrankerFaceZ animated emote links. (#455)
+- Fix: 7TV emote images now resolve correctly. (#456)
 - Dev: Only upload Ubuntu binaries to releases. (#454)
 
 ## 2.0.0

--- a/internal/resolvers/seventv/data_test.go
+++ b/internal/resolvers/seventv/data_test.go
@@ -45,10 +45,10 @@ func init() {
 		},
 	}
 
-	// Regular emote: monkaS
+	// Regular emote: monkaE
 	emotes["603cb219c20d020014423c34"] = EmoteModel{
 		ID:     "603cb219c20d020014423c34",
-		Name:   "monkaS",
+		Name:   "monkaE",
 		Flags:  0,
 		Listed: true,
 		Host: ImageHost{
@@ -58,6 +58,22 @@ func init() {
 		Owner: UserPartialModel{
 			ID:          "6042058896832ffa785800fe",
 			DisplayName: "Zhark",
+		},
+	}
+
+	// Regular emote (in global set): FeelsDankMan
+	emotes["63071bb9464de28875c52531"] = EmoteModel{
+		ID:     "63071bb9464de28875c52531",
+		Name:   "FeelsDankMan",
+		Flags:  0,
+		Listed: true,
+		Host: ImageHost{
+			URL:   "https://cdn.7tv.app/emote/63071bb9464de28875c52531",
+			Files: []ImageFile{{Name: "1x.webp", Width: 28, Height: 28, Format: ImageFormatWEBP}, {Name: "best.webp", Width: 128, Height: 128, Format: ImageFormatWEBP}},
+		},
+		Owner: UserPartialModel{
+			ID:          "603cb1c696832ffa78cc3bc2",
+			DisplayName: "clyverE",
 		},
 	}
 

--- a/internal/resolvers/seventv/data_test.go
+++ b/internal/resolvers/seventv/data_test.go
@@ -2,7 +2,6 @@ package seventv
 
 import (
 	"encoding/json"
-	"io"
 	"net/http"
 	"net/http/httptest"
 
@@ -10,95 +9,95 @@ import (
 )
 
 var (
-	emotes = map[string]EmoteAPIResponse{}
+	emotes = map[string]EmoteModel{}
 )
 
 func init() {
 	// Private emote: Pajawalk
-	emotes["604281c81ae70f000d47ffd9"] = EmoteAPIResponse{
-		Data: EmoteAPIResponseData{
-			Emote: &EmoteAPIEmote{
-				ID:         "604281c81ae70f000d47ffd9",
-				Name:       "Pajawalk",
-				Visibility: EmoteVisibilityPrivate,
-				Owner: EmoteAPIUser{
-					ID:          "603d10e496832ffa787ca53c",
-					DisplayName: "durado_",
-				},
-			},
+	emotes["604281c81ae70f000d47ffd9"] = EmoteModel{
+		ID:     "604281c81ae70f000d47ffd9",
+		Name:   "Pajawalk",
+		Flags:  EmoteFlagsPrivate,
+		Listed: true,
+		Host: ImageHost{
+			URL:   "//cdn.7tv.app/emote/604281c81ae70f000d47ffd9",
+			Files: []ImageFile{{Name: "best.avif", Width: 100, Height: 30, Format: ImageFormatAVIF}, {Name: "best.webp", Width: 90, Height: 28, Format: ImageFormatWEBP}},
+		},
+		Owner: UserPartialModel{
+			ID:          "603d10e496832ffa787ca53c",
+			DisplayName: "durado_",
 		},
 	}
 
-	// Hidden emote: Bedge
-	emotes["60ae8d9ff39a7552b658b60d"] = EmoteAPIResponse{
-		Data: EmoteAPIResponseData{
-			Emote: &EmoteAPIEmote{
-				ID:         "60ae8d9ff39a7552b658b60d",
-				Name:       "Bedge",
-				Visibility: EmoteVisibilityPrivate | EmoteVisibilityHidden,
-				Owner: EmoteAPIUser{
-					ID:          "605394d9b4d31e459ff05f40",
-					DisplayName: "Paruna",
-				},
-			},
+	// Unlisted emote: Bedge
+	emotes["60ae8d9ff39a7552b658b60d"] = EmoteModel{
+		ID:     "60ae8d9ff39a7552b658b60d",
+		Name:   "Bedge",
+		Flags:  0,
+		Listed: false,
+		Host: ImageHost{
+			URL:   "//cdn.7tv.app/emote/60ae8d9ff39a7552b658b60d",
+			Files: []ImageFile{{Name: "best.webp", Width: 90, Height: 28, Format: ImageFormatWEBP}},
+		},
+		Owner: UserPartialModel{
+			ID:          "605394d9b4d31e459ff05f40",
+			DisplayName: "Paruna",
 		},
 	}
 
-	// Global emote: FeelsOkayMan
-	emotes["6042998c1d4963000d9dae34"] = EmoteAPIResponse{
-		Data: EmoteAPIResponseData{
-			Emote: &EmoteAPIEmote{
-				ID:         "6042998c1d4963000d9dae34",
-				Name:       "FeelsOkayMan",
-				Visibility: EmoteVisibilityGlobal,
-				Owner: EmoteAPIUser{
-					ID:          "603bb6a596832ffa78e7b27b",
-					DisplayName: "MegaKill3",
-				},
-			},
+	// Regular emote: monkaS
+	emotes["603cb219c20d020014423c34"] = EmoteModel{
+		ID:     "603cb219c20d020014423c34",
+		Name:   "monkaS",
+		Flags:  0,
+		Listed: true,
+		Host: ImageHost{
+			URL:   "https://cdn.7tv.app/emote/603cb219c20d020014423c34",
+			Files: []ImageFile{{Name: "1x.webp", Width: 28, Height: 28, Format: ImageFormatWEBP}, {Name: "best.webp", Width: 128, Height: 128, Format: ImageFormatWEBP}},
+		},
+		Owner: UserPartialModel{
+			ID:          "6042058896832ffa785800fe",
+			DisplayName: "Zhark",
 		},
 	}
 
-	// No visiblity tag emote: monkaE
-	emotes["603cb219c20d020014423c34"] = EmoteAPIResponse{
-		Data: EmoteAPIResponseData{
-			Emote: &EmoteAPIEmote{
-				ID:   "603cb219c20d020014423c34",
-				Name: "monkaE",
-				// No visibility, should default to shared
-				Owner: EmoteAPIUser{
-					ID:          "6042058896832ffa785800fe",
-					DisplayName: "Zhark",
-				},
-			},
+	// Regular emote, no webp images: Hmm
+	emotes["60ae3e54259ac5a73e56a426"] = EmoteModel{
+		ID:     "60ae3e54259ac5a73e56a426",
+		Name:   "Hmm",
+		Flags:  0,
+		Listed: true,
+		Host: ImageHost{
+			URL:   "https://cdn.7tv.app/emote/60ae3e54259ac5a73e56a426",
+			Files: []ImageFile{{Name: "jebaited.webp", Width: 128, Height: 128, Format: ImageFormatAVIF}},
+		},
+		Owner: UserPartialModel{
+			ID:          "60772a85a807bed00612d1ee",
+			DisplayName: "lnsc",
 		},
 	}
 
-	// No emote
-	emotes["f0f0f0"] = EmoteAPIResponse{
-		Data: EmoteAPIResponseData{
-			Emote: nil,
+	// Private, unlisted emote: Okayge
+	emotes["60bcb44f7229037ee386d1ab"] = EmoteModel{
+		ID:     "60bcb44f7229037ee386d1ab",
+		Name:   "Okayge",
+		Flags:  EmoteFlagsPrivate,
+		Listed: false,
+		Host: ImageHost{
+			URL:   "//cdn.7tv.app/emote/60bcb44f7229037ee386d1ab",
+			Files: []ImageFile{{Name: "1x.webp", Width: 28, Height: 28, Format: ImageFormatWEBP}, {Name: "best.webp", Width: 128, Height: 128, Format: ImageFormatWEBP}, {Name: "2x.webp", Width: 42, Height: 42, Format: ImageFormatWEBP}},
+		},
+		Owner: UserPartialModel{
+			ID:          "60aeabfff6a2c3b332dd6a35",
+			DisplayName: "joonwi",
 		},
 	}
 }
 
 func testServer() *httptest.Server {
 	r := chi.NewRouter()
-	r.Post("/v2/gql", func(w http.ResponseWriter, r *http.Request) {
-		type gqlQuery struct {
-			Query     string            `json:"string"`
-			Variables map[string]string `json:"variables"`
-		}
-
-		var q gqlQuery
-
-		xd, _ := io.ReadAll(r.Body)
-		err := json.Unmarshal(xd, &q)
-		if err != nil {
-			panic(err)
-		}
-
-		emoteID := q.Variables["id"]
+	r.Get("/v3/emotes/{id}", func(w http.ResponseWriter, r *http.Request) {
+		emoteID := chi.URLParam(r, "id")
 
 		if emoteID == "bad" {
 			w.Header().Set("Content-Type", "application/json")

--- a/internal/resolvers/seventv/emote_resolver_test.go
+++ b/internal/resolvers/seventv/emote_resolver_test.go
@@ -26,7 +26,7 @@ func TestEmoteResolver(t *testing.T) {
 	cfg := config.APIConfig{
 		BaseURL: "https://example.com/chatterino/",
 	}
-	apiURL := utils.MustParseURL(ts.URL + "/v2/gql")
+	apiURL := utils.MustParseURL(ts.URL + "/v3/emotes")
 
 	resolver := NewEmoteResolver(ctx, cfg, pool, apiURL)
 
@@ -180,43 +180,55 @@ func TestEmoteResolver(t *testing.T) {
 					inputEmoteHash: "604281c81ae70f000d47ffd9",
 					inputReq:       nil,
 					expectedResponse: &cache.Response{
-						Payload:     []byte(`{"status":200,"thumbnail":"https://example.com/chatterino/thumbnail/https%3A%2F%2Fcdn.7tv.app%2Femote%2F604281c81ae70f000d47ffd9%2F4x","tooltip":"%3Cdiv%20style=%22text-align:%20left%3B%22%3E%0A%3Cb%3EPajawalk%3C%2Fb%3E%3Cbr%3E%0A%3Cb%3EPrivate%20SevenTV%20Emote%3C%2Fb%3E%3Cbr%3E%0A%3Cb%3EBy:%3C%2Fb%3E%20durado_%0A%3C%2Fdiv%3E","link":"https://7tv.app/emotes/604281c81ae70f000d47ffd9"}`),
+						Payload:     []byte(`{"status":200,"thumbnail":"https://example.com/chatterino/thumbnail/https%3A%2F%2Fcdn.7tv.app%2Femote%2F604281c81ae70f000d47ffd9%2Fbest.webp","tooltip":"%3Cdiv%20style=%22text-align:%20left%3B%22%3E%0A%3Cb%3EPajawalk%3C%2Fb%3E%3Cbr%3E%0A%3Cb%3EPrivate%207TV%20Emote%3C%2Fb%3E%3Cbr%3E%0A%3Cb%3EBy:%3C%2Fb%3E%20durado_%0A%3C%2Fdiv%3E","link":"https://7tv.app/emotes/604281c81ae70f000d47ffd9"}`),
 						StatusCode:  http.StatusOK,
 						ContentType: "application/json",
 					},
 					expectedError: nil,
 				},
 				{
-					label:          "Hidden",
+					label:          "Unlisted",
 					inputURL:       utils.MustParseURL("https://7tv.app/emotes/60ae8d9ff39a7552b658b60d"),
 					inputEmoteHash: "60ae8d9ff39a7552b658b60d",
 					inputReq:       nil,
 					expectedResponse: &cache.Response{
-						Payload:     []byte(`{"status":200,"tooltip":"%3Cdiv%20style=%22text-align:%20left%3B%22%3E%0A%3Cb%3EBedge%3C%2Fb%3E%3Cbr%3E%0A%3Cb%3EPrivate%20SevenTV%20Emote%3C%2Fb%3E%3Cbr%3E%0A%3Cb%3EBy:%3C%2Fb%3E%20Paruna%0A%3Cli%3E%3Cb%3E%3Cspan%20style=%22color:%20red%3B%22%3EUNLISTED%3C%2Fspan%3E%3C%2Fb%3E%3C%2Fli%3E%0A%3C%2Fdiv%3E","link":"https://7tv.app/emotes/60ae8d9ff39a7552b658b60d"}`),
+						Payload:     []byte(`{"status":200,"tooltip":"%3Cdiv%20style=%22text-align:%20left%3B%22%3E%0A%3Cb%3EBedge%3C%2Fb%3E%3Cbr%3E%0A%3Cb%3EShared%207TV%20Emote%3C%2Fb%3E%3Cbr%3E%0A%3Cb%3EBy:%3C%2Fb%3E%20Paruna%0A%3Cli%3E%3Cb%3E%3Cspan%20style=%22color:%20red%3B%22%3EUNLISTED%3C%2Fspan%3E%3C%2Fb%3E%3C%2Fli%3E%0A%3C%2Fdiv%3E","link":"https://7tv.app/emotes/60ae8d9ff39a7552b658b60d"}`),
 						StatusCode:  http.StatusOK,
 						ContentType: "application/json",
 					},
 					expectedError: nil,
 				},
 				{
-					label:          "Global",
-					inputURL:       utils.MustParseURL("https://7tv.app/emotes/6042998c1d4963000d9dae34"),
-					inputEmoteHash: "6042998c1d4963000d9dae34",
-					inputReq:       nil,
-					expectedResponse: &cache.Response{
-						Payload:     []byte(`{"status":200,"thumbnail":"https://example.com/chatterino/thumbnail/https%3A%2F%2Fcdn.7tv.app%2Femote%2F6042998c1d4963000d9dae34%2F4x","tooltip":"%3Cdiv%20style=%22text-align:%20left%3B%22%3E%0A%3Cb%3EFeelsOkayMan%3C%2Fb%3E%3Cbr%3E%0A%3Cb%3EGlobal%20SevenTV%20Emote%3C%2Fb%3E%3Cbr%3E%0A%3Cb%3EBy:%3C%2Fb%3E%20MegaKill3%0A%3C%2Fdiv%3E","link":"https://7tv.app/emotes/6042998c1d4963000d9dae34"}`),
-						StatusCode:  http.StatusOK,
-						ContentType: "application/json",
-					},
-					expectedError: nil,
-				},
-				{
-					label:          "Missing visibility",
+					label:          "Regular",
 					inputURL:       utils.MustParseURL("https://7tv.app/emotes/603cb219c20d020014423c34"),
 					inputEmoteHash: "603cb219c20d020014423c34",
 					inputReq:       nil,
 					expectedResponse: &cache.Response{
-						Payload:     []byte(`{"status":200,"thumbnail":"https://example.com/chatterino/thumbnail/https%3A%2F%2Fcdn.7tv.app%2Femote%2F603cb219c20d020014423c34%2F4x","tooltip":"%3Cdiv%20style=%22text-align:%20left%3B%22%3E%0A%3Cb%3EmonkaE%3C%2Fb%3E%3Cbr%3E%0A%3Cb%3EShared%20SevenTV%20Emote%3C%2Fb%3E%3Cbr%3E%0A%3Cb%3EBy:%3C%2Fb%3E%20Zhark%0A%3C%2Fdiv%3E","link":"https://7tv.app/emotes/603cb219c20d020014423c34"}`),
+						Payload:     []byte(`{"status":200,"thumbnail":"https://example.com/chatterino/thumbnail/https%3A%2F%2Fcdn.7tv.app%2Femote%2F603cb219c20d020014423c34%2Fbest.webp","tooltip":"%3Cdiv%20style=%22text-align:%20left%3B%22%3E%0A%3Cb%3EmonkaS%3C%2Fb%3E%3Cbr%3E%0A%3Cb%3EShared%207TV%20Emote%3C%2Fb%3E%3Cbr%3E%0A%3Cb%3EBy:%3C%2Fb%3E%20Zhark%0A%3C%2Fdiv%3E","link":"https://7tv.app/emotes/603cb219c20d020014423c34"}`),
+						StatusCode:  http.StatusOK,
+						ContentType: "application/json",
+					},
+					expectedError: nil,
+				},
+				{
+					label:          "Regular, no images",
+					inputURL:       utils.MustParseURL("https://7tv.app/emotes/60ae3e54259ac5a73e56a426"),
+					inputEmoteHash: "60ae3e54259ac5a73e56a426",
+					inputReq:       nil,
+					expectedResponse: &cache.Response{
+						Payload:     []byte(`{"status":200,"tooltip":"%3Cdiv%20style=%22text-align:%20left%3B%22%3E%0A%3Cb%3EHmm%3C%2Fb%3E%3Cbr%3E%0A%3Cb%3EShared%207TV%20Emote%3C%2Fb%3E%3Cbr%3E%0A%3Cb%3EBy:%3C%2Fb%3E%20lnsc%0A%3C%2Fdiv%3E","link":"https://7tv.app/emotes/60ae3e54259ac5a73e56a426"}`),
+						StatusCode:  http.StatusOK,
+						ContentType: "application/json",
+					},
+					expectedError: nil,
+				},
+				{
+					label:          "Unlisted, Private",
+					inputURL:       utils.MustParseURL("https://7tv.app/emotes/60bcb44f7229037ee386d1ab"),
+					inputEmoteHash: "60bcb44f7229037ee386d1ab",
+					inputReq:       nil,
+					expectedResponse: &cache.Response{
+						Payload:     []byte(`{"status":200,"tooltip":"%3Cdiv%20style=%22text-align:%20left%3B%22%3E%0A%3Cb%3EOkayge%3C%2Fb%3E%3Cbr%3E%0A%3Cb%3EPrivate%207TV%20Emote%3C%2Fb%3E%3Cbr%3E%0A%3Cb%3EBy:%3C%2Fb%3E%20joonwi%0A%3Cli%3E%3Cb%3E%3Cspan%20style=%22color:%20red%3B%22%3EUNLISTED%3C%2Fspan%3E%3C%2Fb%3E%3C%2Fli%3E%0A%3C%2Fdiv%3E","link":"https://7tv.app/emotes/60bcb44f7229037ee386d1ab"}`),
 						StatusCode:  http.StatusOK,
 						ContentType: "application/json",
 					},
@@ -228,7 +240,7 @@ func TestEmoteResolver(t *testing.T) {
 					inputEmoteHash: "404",
 					inputReq:       nil,
 					expectedResponse: &cache.Response{
-						Payload:     []byte(`{"status":404,"message":"No SevenTV emote with this id found"}`),
+						Payload:     []byte(`{"status":404,"message":"No 7TV emote with this id found"}`),
 						StatusCode:  http.StatusOK,
 						ContentType: "application/json",
 					},
@@ -240,7 +252,7 @@ func TestEmoteResolver(t *testing.T) {
 					inputEmoteHash: "f0f0f0",
 					inputReq:       nil,
 					expectedResponse: &cache.Response{
-						Payload:     []byte(`{"status":404,"message":"No SevenTV emote with this id found"}`),
+						Payload:     []byte(`{"status":404,"message":"No 7TV emote with this id found"}`),
 						StatusCode:  http.StatusOK,
 						ContentType: "application/json",
 					},
@@ -252,7 +264,7 @@ func TestEmoteResolver(t *testing.T) {
 					inputEmoteHash: "bad",
 					inputReq:       nil,
 					expectedResponse: &cache.Response{
-						Payload:     []byte(`{"status":500,"message":"SevenTV API response decode error: invalid character \u0026#39;x\u0026#39; looking for beginning of value"}`),
+						Payload:     []byte(`{"status":500,"message":"7TV API response decode error: invalid character \u0026#39;x\u0026#39; looking for beginning of value"}`),
 						StatusCode:  http.StatusOK,
 						ContentType: "application/json",
 					},

--- a/internal/resolvers/seventv/emote_resolver_test.go
+++ b/internal/resolvers/seventv/emote_resolver_test.go
@@ -204,7 +204,19 @@ func TestEmoteResolver(t *testing.T) {
 					inputEmoteHash: "603cb219c20d020014423c34",
 					inputReq:       nil,
 					expectedResponse: &cache.Response{
-						Payload:     []byte(`{"status":200,"thumbnail":"https://example.com/chatterino/thumbnail/https%3A%2F%2Fcdn.7tv.app%2Femote%2F603cb219c20d020014423c34%2Fbest.webp","tooltip":"%3Cdiv%20style=%22text-align:%20left%3B%22%3E%0A%3Cb%3EmonkaS%3C%2Fb%3E%3Cbr%3E%0A%3Cb%3EShared%207TV%20Emote%3C%2Fb%3E%3Cbr%3E%0A%3Cb%3EBy:%3C%2Fb%3E%20Zhark%0A%3C%2Fdiv%3E","link":"https://7tv.app/emotes/603cb219c20d020014423c34"}`),
+						Payload:     []byte(`{"status":200,"thumbnail":"https://example.com/chatterino/thumbnail/https%3A%2F%2Fcdn.7tv.app%2Femote%2F603cb219c20d020014423c34%2Fbest.webp","tooltip":"%3Cdiv%20style=%22text-align:%20left%3B%22%3E%0A%3Cb%3EmonkaE%3C%2Fb%3E%3Cbr%3E%0A%3Cb%3EShared%207TV%20Emote%3C%2Fb%3E%3Cbr%3E%0A%3Cb%3EBy:%3C%2Fb%3E%20Zhark%0A%3C%2Fdiv%3E","link":"https://7tv.app/emotes/603cb219c20d020014423c34"}`),
+						StatusCode:  http.StatusOK,
+						ContentType: "application/json",
+					},
+					expectedError: nil,
+				},
+				{
+					label:          "Regular,global",
+					inputURL:       utils.MustParseURL("https://7tv.app/emotes/63071bb9464de28875c52531"),
+					inputEmoteHash: "63071bb9464de28875c52531",
+					inputReq:       nil,
+					expectedResponse: &cache.Response{
+						Payload:     []byte(`{"status":200,"thumbnail":"https://example.com/chatterino/thumbnail/https%3A%2F%2Fcdn.7tv.app%2Femote%2F63071bb9464de28875c52531%2Fbest.webp","tooltip":"%3Cdiv%20style=%22text-align:%20left%3B%22%3E%0A%3Cb%3EFeelsDankMan%3C%2Fb%3E%3Cbr%3E%0A%3Cb%3EShared%207TV%20Emote%3C%2Fb%3E%3Cbr%3E%0A%3Cb%3EBy:%3C%2Fb%3E%20clyverE%0A%3C%2Fdiv%3E","link":"https://7tv.app/emotes/63071bb9464de28875c52531"}`),
 						StatusCode:  http.StatusOK,
 						ContentType: "application/json",
 					},

--- a/internal/resolvers/seventv/initialize.go
+++ b/internal/resolvers/seventv/initialize.go
@@ -13,11 +13,9 @@ import (
 )
 
 const (
-	thumbnailFormat = "https://cdn.7tv.app/emote/%s/4x"
-
 	tooltipTemplate = `<div style="text-align: left;">
 <b>{{.Code}}</b><br>
-<b>{{.Type}} SevenTV Emote</b><br>
+<b>{{.Type}} 7TV Emote</b><br>
 <b>By:</b> {{.Uploader}}` +
 		`{{ if .Unlisted }}` + `
 <li><b><span style="color: red;">UNLISTED</span></b></li>{{ end }}
@@ -37,7 +35,7 @@ var (
 )
 
 func Initialize(ctx context.Context, cfg config.APIConfig, pool db.Pool, resolvers *[]resolver.Resolver) {
-	apiURL := utils.MustParseURL("https://api.7tv.app/v2/gql")
+	apiURL := utils.MustParseURL("https://7tv.io/v3/emotes")
 
 	*resolvers = append(*resolvers, NewEmoteResolver(ctx, cfg, pool, apiURL))
 }

--- a/internal/resolvers/seventv/model.go
+++ b/internal/resolvers/seventv/model.go
@@ -18,7 +18,7 @@ type EmoteModel struct {
 	Name   string           `json:"name"`
 	Flags  EmoteFlagsModel  `json:"flags"`
 	Listed bool             `json:"listed"`
-	Owner  UserPartialModel `json:"owner,omitempty" extensions:"x-omitempty"`
+	Owner  UserPartialModel `json:"owner"`
 	Host   ImageHost        `json:"host"`
 }
 

--- a/internal/resolvers/seventv/model.go
+++ b/internal/resolvers/seventv/model.go
@@ -1,25 +1,5 @@
 package seventv
 
-type EmoteAPIUser struct {
-	ID          string `json:"id"`
-	DisplayName string `json:"display_name"`
-}
-
-type EmoteAPIEmote struct {
-	ID         string       `json:"id"`
-	Name       string       `json:"name"`
-	Visibility int32        `json:"visibility"`
-	Owner      EmoteAPIUser `json:"owner"`
-}
-
-type EmoteAPIResponseData struct {
-	Emote *EmoteAPIEmote `json:"emote,omitempty"`
-}
-
-type EmoteAPIResponse struct {
-	Data EmoteAPIResponseData `json:"data"`
-}
-
 type TooltipData struct {
 	Code     string
 	Type     string
@@ -28,14 +8,55 @@ type TooltipData struct {
 	Unlisted bool
 }
 
-const (
-	EmoteVisibilityPrivate int32 = 1 << iota
-	EmoteVisibilityGlobal
-	EmoteVisibilityHidden
-	EmoteVisibilityOverrideBTTV
-	EmoteVisibilityOverrideFFZ
-	EmoteVisibilityOverrideTwitchGlobal
-	EmoteVisibilityOverrideTwitchSubscriber
+// Definitions from:
+// * Emotes: https://github.com/SevenTV/API/blob/a907ccc44e7eb5bdba7b7e63d2b4b67e0c04f778/data/model/emote.model.go
+// * Users: https://github.com/SevenTV/API/blob/a907ccc44e7eb5bdba7b7e63d2b4b67e0c04f778/data/model/user.model.go
+// * Images: https://github.com/SevenTV/API/blob/a907ccc44e7eb5bdba7b7e63d2b4b67e0c04f778/data/model/model.go
 
-	EmoteVisibilityAll int32 = (1 << iota) - 1
+type EmoteModel struct {
+	ID     string           `json:"id"`
+	Name   string           `json:"name"`
+	Flags  EmoteFlagsModel  `json:"flags"`
+	Listed bool             `json:"listed"`
+	Owner  UserPartialModel `json:"owner,omitempty" extensions:"x-omitempty"`
+	Host   ImageHost        `json:"host"`
+}
+
+type EmoteFlagsModel int32
+
+const (
+	EmoteFlagsPrivate   EmoteFlagsModel = 1 << 0 // The emote is private and can only be accessed by its owner, editors and moderators
+	EmoteFlagsAuthentic EmoteFlagsModel = 1 << 1 // The emote was verified to be an original creation by the uploader
+	EmoteFlagsZeroWidth EmoteFlagsModel = 1 << 8 // The emote is recommended to be enabled as Zero-Width
+
+	// Content Flags
+
+	EmoteFlagsContentSexual           EmoteFlagsModel = 1 << 16 // Sexually Suggesive
+	EmoteFlagsContentEpilepsy         EmoteFlagsModel = 1 << 17 // Rapid flashing
+	EmoteFlagsContentEdgy             EmoteFlagsModel = 1 << 18 // Edgy or distasteful, may be offensive to some users
+	EmoteFlagsContentTwitchDisallowed EmoteFlagsModel = 1 << 24 // Not allowed specifically on the Twitch platform
 )
+
+type ImageHost struct {
+	URL   string      `json:"url"`
+	Files []ImageFile `json:"files"`
+}
+
+type ImageFile struct {
+	Name   string      `json:"name"`
+	Width  int32       `json:"width"`
+	Height int32       `json:"height"`
+	Format ImageFormat `json:"format"`
+}
+
+type ImageFormat string
+
+const (
+	ImageFormatAVIF ImageFormat = "AVIF"
+	ImageFormatWEBP ImageFormat = "WEBP"
+)
+
+type UserPartialModel struct {
+	ID          string `json:"id"`
+	DisplayName string `json:"display_name"`
+}

--- a/internal/resolvers/seventv/model.go
+++ b/internal/resolvers/seventv/model.go
@@ -27,8 +27,10 @@ type EmoteFlagsModel int32
 const (
 	// The emote is private and can only be accessed by its owner, editors and moderators
 	EmoteFlagsPrivate EmoteFlagsModel = 1 << 0
+
 	// The emote was verified to be an original creation by the uploader
 	EmoteFlagsAuthentic EmoteFlagsModel = 1 << 1
+
 	// The emote is recommended to be enabled as Zero-Width
 	EmoteFlagsZeroWidth EmoteFlagsModel = 1 << 8
 
@@ -36,10 +38,13 @@ const (
 
 	// Sexually Suggesive
 	EmoteFlagsContentSexual EmoteFlagsModel = 1 << 16
+
 	// Rapid flashing
 	EmoteFlagsContentEpilepsy EmoteFlagsModel = 1 << 17
+
 	// Edgy or distasteful, may be offensive to some users
 	EmoteFlagsContentEdgy EmoteFlagsModel = 1 << 18
+	
 	// Not allowed specifically on the Twitch platform
 	EmoteFlagsContentTwitchDisallowed EmoteFlagsModel = 1 << 24
 )

--- a/internal/resolvers/seventv/model.go
+++ b/internal/resolvers/seventv/model.go
@@ -44,7 +44,7 @@ const (
 
 	// Edgy or distasteful, may be offensive to some users
 	EmoteFlagsContentEdgy EmoteFlagsModel = 1 << 18
-	
+
 	// Not allowed specifically on the Twitch platform
 	EmoteFlagsContentTwitchDisallowed EmoteFlagsModel = 1 << 24
 )

--- a/internal/resolvers/seventv/model.go
+++ b/internal/resolvers/seventv/model.go
@@ -25,16 +25,23 @@ type EmoteModel struct {
 type EmoteFlagsModel int32
 
 const (
-	EmoteFlagsPrivate   EmoteFlagsModel = 1 << 0 // The emote is private and can only be accessed by its owner, editors and moderators
-	EmoteFlagsAuthentic EmoteFlagsModel = 1 << 1 // The emote was verified to be an original creation by the uploader
-	EmoteFlagsZeroWidth EmoteFlagsModel = 1 << 8 // The emote is recommended to be enabled as Zero-Width
+	// The emote is private and can only be accessed by its owner, editors and moderators
+	EmoteFlagsPrivate EmoteFlagsModel = 1 << 0
+	// The emote was verified to be an original creation by the uploader
+	EmoteFlagsAuthentic EmoteFlagsModel = 1 << 1
+	// The emote is recommended to be enabled as Zero-Width
+	EmoteFlagsZeroWidth EmoteFlagsModel = 1 << 8
 
 	// Content Flags
 
-	EmoteFlagsContentSexual           EmoteFlagsModel = 1 << 16 // Sexually Suggesive
-	EmoteFlagsContentEpilepsy         EmoteFlagsModel = 1 << 17 // Rapid flashing
-	EmoteFlagsContentEdgy             EmoteFlagsModel = 1 << 18 // Edgy or distasteful, may be offensive to some users
-	EmoteFlagsContentTwitchDisallowed EmoteFlagsModel = 1 << 24 // Not allowed specifically on the Twitch platform
+	// Sexually Suggesive
+	EmoteFlagsContentSexual EmoteFlagsModel = 1 << 16
+	// Rapid flashing
+	EmoteFlagsContentEpilepsy EmoteFlagsModel = 1 << 17
+	// Edgy or distasteful, may be offensive to some users
+	EmoteFlagsContentEdgy EmoteFlagsModel = 1 << 18
+	// Not allowed specifically on the Twitch platform
+	EmoteFlagsContentTwitchDisallowed EmoteFlagsModel = 1 << 24
 )
 
 type ImageHost struct {

--- a/internal/resolvers/seventv/static_responses.go
+++ b/internal/resolvers/seventv/static_responses.go
@@ -9,6 +9,6 @@ import (
 var (
 	emoteNotFoundResponse = &resolver.Response{
 		Status:  http.StatusNotFound,
-		Message: "No SevenTV emote with this id found",
+		Message: "No 7TV emote with this id found",
 	}
 )


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

This PR updates the 7TV resolver to use the V3 API since V2 is deprecated. This fixes an issue of emote-images not appearing because [a static template was used](https://github.com/Chatterino/api/blob/13079e183e79dd0c796a975fa6d268023b702f32/internal/resolvers/seventv/initialize.go#L16). Furthermore, all public mentions of "SevenTV" have been replaced to "7TV".
