### PR TITLE
Remove `Get external dependencies (MacOS)` CI step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,10 +29,6 @@ jobs:
         if: matrix.os == 'ubuntu-22.04'
         run: sudo apt update && sudo apt -y install build-essential libvips-dev
 
-      - name: Get external dependencies (MacOS)
-        if: matrix.os == 'macos-latest'
-        run: brew install vips
-
       - name: Get Go dependencies
         run: |
           go get -v -t -d ./...


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

I noticed that the step seemed to always have been skipped, I thought that MacOS builds for the API were dropped and I found https://github.com/Chatterino/api/pull/438 which confirmed that to me.