### PR TITLE
Load Tweets using embed endpoint if no API key is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Breaking: Remove the `/twitchemotes/` endpoints. See [issue 332](https://github.com/Chatterino/api/issues/332) for more information. (#465)
+- Minor: Load Tweets using embed endpoint if no API key is present. (#510)
 - Fix: We do some more YouTube video ID parsing to ensure broken links (such as `youtube.com/watch?v=foobar?feature=share`) still return the actual video ID, since this is how the browser operates. (#488)
 - Dev: Document the `log-development` setting. (#491)
 - Dev: Document the `log-level` setting. (#490)

--- a/internal/resolvers/twitter/data_test.go
+++ b/internal/resolvers/twitter/data_test.go
@@ -12,6 +12,7 @@ import (
 var (
 	users  = map[string]*TwitterUserApiResponse{}
 	tweets = map[string]*TweetApiResponse{}
+	embeds = map[string]*EmbedApiResponse{}
 )
 
 func init() {
@@ -101,6 +102,52 @@ func init() {
 			},
 		},
 	}
+
+	// Embed with one photo
+	embeds["1541102101782216706"] = &EmbedApiResponse{
+		Text:      "Since I switched to rifle and 4:3 its been pretty easy. People calling me bad when they were already playing on the easiest difficulty🤣🤣🤣😎 https://t.co/jfbLdsPTwZ",
+		ID:        "1541102101782216706",
+		CreatedAt: time.Date(2022, time.June, 26, 16, 52, 28, 0, time.UTC),
+		User: EmbedUser{
+			Name:       "Sebastian Fors",
+			ScreenName: "Forsen",
+		},
+		FavoriteCount:     4966,
+		ConversationCount: 242,
+		MediaDetails: []EmbedMediaDetail{
+			{
+				MediaUrl: "https://pbs.twimg.com/media/FWMYHYSWYAAyWMp.jpg",
+			},
+		},
+	}
+
+	// Embed without media
+	embeds["1662863815787126787"] = &EmbedApiResponse{
+		Text:      "Playing some more warlander today on stream! Free to play and join! Get it here https://t.co/rh3IBOvymE ! @PlayWarlander #Warlander",
+		ID:        "1662863815787126787",
+		CreatedAt: time.Date(2023, time.May, 28, 16, 50, 2, 0, time.UTC),
+		User: EmbedUser{
+			Name:       "Sebastian Fors",
+			ScreenName: "Forsen",
+		},
+		FavoriteCount:     437,
+		ConversationCount: 87,
+		MediaDetails:      []EmbedMediaDetail{},
+	}
+
+	// Embed without id
+	embeds["1662863815787126788"] = &EmbedApiResponse{
+		Text:      "",
+		ID:        "",
+		CreatedAt: time.Date(2023, time.May, 28, 16, 50, 2, 0, time.UTC),
+		User: EmbedUser{
+			Name:       "Sebastian Fors",
+			ScreenName: "Forsen",
+		},
+		FavoriteCount:     437,
+		ConversationCount: 87,
+		MediaDetails:      []EmbedMediaDetail{},
+	}
 }
 
 func testServer() *httptest.Server {
@@ -141,6 +188,33 @@ func testServer() *httptest.Server {
 			http.Error(w, http.StatusText(500), 500)
 			return
 		} else if response, ok = tweets[tweetID]; !ok {
+			http.Error(w, http.StatusText(404), 404)
+			return
+		}
+
+		b, _ := json.Marshal(&response)
+
+		w.Write(b)
+	})
+	return httptest.NewServer(r)
+}
+
+func testEmbedServer() *httptest.Server {
+	r := chi.NewRouter()
+	r.Get("/tweet-result", func(w http.ResponseWriter, r *http.Request) {
+		tweetID := r.URL.Query().Get("id")
+
+		var response *EmbedApiResponse
+		var ok bool
+
+		w.Header().Set("Content-Type", "application/json")
+
+		if tweetID == "bad" {
+			w.Write([]byte("xD"))
+		} else if tweetID == "500" {
+			http.Error(w, http.StatusText(500), 500)
+			return
+		} else if response, ok = embeds[tweetID]; !ok {
 			http.Error(w, http.StatusText(404), 404)
 			return
 		}

--- a/internal/resolvers/twitter/embed_loader.go
+++ b/internal/resolvers/twitter/embed_loader.go
@@ -1,0 +1,210 @@
+package twitter
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/Chatterino/api/internal/logger"
+	"github.com/Chatterino/api/pkg/cache"
+	"github.com/Chatterino/api/pkg/humanize"
+	"github.com/Chatterino/api/pkg/resolver"
+	"github.com/Chatterino/api/pkg/utils"
+)
+
+type EmbedApiResponse struct {
+	Text              string             `json:"text"`
+	ID                string             `json:"id_str"`
+	CreatedAt         time.Time          `json:"created_at"`
+	User              EmbedUser          `json:"user"`
+	FavoriteCount     uint64             `json:"favorite_count"`
+	ConversationCount uint64             `json:"conversation_count"`
+	MediaDetails      []EmbedMediaDetail `json:"mediaDetails"`
+}
+
+type EmbedUser struct {
+	Name       string `json:"name"`
+	ScreenName string `json:"screen_name"`
+}
+
+type EmbedMediaDetail struct {
+	MediaUrl string `json:"media_url_https"`
+}
+
+func (e EmbedMediaDetail) Url() string {
+	return e.MediaUrl
+}
+
+type EmbedLoader struct {
+	baseURL               string
+	endpointURLFormat     string
+	tweetCacheKeyProvider cache.KeyProvider
+	collageCache          cache.DependentCache
+	maxThumbnailSize      uint
+}
+
+type embedTweetTooltipData struct {
+	Text      string
+	Name      string
+	Username  string
+	Timestamp string
+	Likes     string
+	Replies   string
+	Thumbnail string
+}
+
+func NewEmbedLoader(
+	baseURL string,
+	endpointURLFormat string,
+	tweetCacheKeyProvider cache.KeyProvider,
+	collageCache cache.DependentCache,
+	maxThumbnailSize uint,
+) *EmbedLoader {
+	return &EmbedLoader{
+		baseURL:               baseURL,
+		endpointURLFormat:     endpointURLFormat,
+		tweetCacheKeyProvider: tweetCacheKeyProvider,
+		collageCache:          collageCache,
+		maxThumbnailSize:      maxThumbnailSize,
+	}
+}
+
+func (l *EmbedLoader) getTweetByID(id string) (*EmbedApiResponse, error) {
+	endpointUrl := fmt.Sprintf(l.endpointURLFormat, id)
+	resp, err := resolver.RequestGETWithHeaders(endpointUrl, map[string]string{})
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, errTweetNotFound
+	}
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("unhandled status code: %d", resp.StatusCode)
+	}
+
+	var tweet *EmbedApiResponse
+	err = json.NewDecoder(resp.Body).Decode(&tweet)
+	if err != nil {
+		return nil, errors.New("unable to unmarshal response")
+	}
+
+	// deleted tweets do not return 404, but contain no data instead
+	// example ID: 1616441855495016450
+	if tweet.ID == "" {
+		return nil, errTweetNotFound
+	}
+
+	return tweet, nil
+}
+
+func (l *EmbedLoader) Load(
+	ctx context.Context,
+	tweetID string,
+	r *http.Request,
+) (*resolver.Response, time.Duration, error) {
+	log := logger.FromContext(ctx)
+
+	log.Debugw("[Twitter Embed] Get tweet",
+		"tweetID", tweetID,
+	)
+
+	tweetResp, err := l.getTweetByID(tweetID)
+	if err != nil {
+		if err == errTweetNotFound {
+			return &resolver.Response{
+				Status:  http.StatusNotFound,
+				Message: fmt.Sprintf("Twitter tweet not found: %s", resolver.CleanResponse(tweetID)),
+			}, cache.NoSpecialDur, nil
+		}
+
+		return resolver.Errorf("Twitter tweet API error: %s", err)
+	}
+
+	tooltipData := l.buildTweetTooltip(ctx, tweetResp, r)
+
+	var tooltip bytes.Buffer
+	if err := embedTweetTooltipTemplate.Execute(&tooltip, tooltipData); err != nil {
+		return resolver.Errorf("Twitter tweet template error: %s", err)
+	}
+
+	return &resolver.Response{
+		Status:    http.StatusOK,
+		Tooltip:   url.PathEscape(tooltip.String()),
+		Thumbnail: tooltipData.Thumbnail,
+	}, cache.NoSpecialDur, nil
+}
+
+func (l *EmbedLoader) buildTweetTooltip(
+	ctx context.Context,
+	tweet *EmbedApiResponse,
+	r *http.Request,
+) *embedTweetTooltipData {
+	data := &embedTweetTooltipData{}
+	data.Text = tweet.Text
+	data.Name = tweet.User.Name
+	data.Username = tweet.User.ScreenName
+	data.Likes = humanize.Number(tweet.FavoriteCount)
+	data.Replies = humanize.Number(tweet.ConversationCount)
+	data.Timestamp = humanize.CreationDateTime(tweet.CreatedAt)
+	data.Thumbnail = l.buildThumbnailURL(ctx, tweet, r)
+
+	return data
+}
+
+func (l *EmbedLoader) buildThumbnailURL(
+	ctx context.Context,
+	tweet *EmbedApiResponse,
+	r *http.Request,
+) string {
+	log := logger.FromContext(ctx)
+
+	numMedia := len(tweet.MediaDetails)
+	if numMedia == 0 {
+		return ""
+	}
+
+	// If tweet contains exactly one image, it will be used as thumbnail
+	if numMedia == 1 {
+		return tweet.MediaDetails[0].MediaUrl
+	}
+
+	// More than one media item, need to compose a thumbnail
+	thumb, err := composeThumbnail(ctx, tweet.MediaDetails, int(l.maxThumbnailSize))
+	if err != nil {
+		log.Errorw("Couldn't compose Twitter collage",
+			"err", err,
+		)
+		return ""
+	}
+
+	outputBuf, metaData, err := thumb.ExportNative()
+	if err != nil {
+		log.Errorw("Couldn't export Twitter collage thumbnail",
+			"err", err,
+		)
+		return ""
+	}
+
+	parentKey := l.tweetCacheKeyProvider.CacheKey(ctx, tweet.ID)
+	collageKey := buildCollageKey(tweet.ID)
+	contentType := utils.MimeType(metaData.Format)
+
+	err = l.collageCache.Insert(ctx, collageKey, parentKey, outputBuf, contentType)
+	if err != nil {
+		log.Errorw("Couldn't insert Twitter collage thumbnail into cache",
+			"err", err,
+		)
+		return ""
+	}
+
+	return utils.FormatGeneratedThumbnailURL(l.baseURL, r, collageKey)
+}

--- a/internal/resolvers/twitter/initialize.go
+++ b/internal/resolvers/twitter/initialize.go
@@ -23,6 +23,15 @@ const (
 </div>
 `
 
+	embedTweetTooltip = `<div style="text-align: left;">
+<b>{{.Name}} (@{{.Username}})</b>
+<span style="white-space: pre-wrap; word-wrap: break-word;">
+{{.Text}}
+</span>
+<span style="color: #808892;">{{.Likes}} likes&nbsp;•&nbsp;{{.Replies}} replies&nbsp;•&nbsp;{{.Timestamp}}</span>
+</div>
+`
+
 	twitterUserTooltip = `<div style="text-align: left;">
 <b>{{.Name}} (@{{.Username}})</b>
 <span style="white-space: pre-wrap; word-wrap: break-word;">
@@ -57,7 +66,8 @@ var (
 		"privacy",
 	})
 
-	tweetTooltipTemplate = template.Must(template.New("tweetTooltip").Parse(tweetTooltip))
+	tweetTooltipTemplate      = template.Must(template.New("tweetTooltip").Parse(tweetTooltip))
+	embedTweetTooltipTemplate = template.Must(template.New("tweetTooltip2").Parse(embedTweetTooltip))
 
 	twitterUserTooltipTemplate = template.Must(template.New("twitterUserTooltip").Parse(twitterUserTooltip))
 )
@@ -71,7 +81,19 @@ func Initialize(
 ) {
 	log := logger.FromContext(ctx)
 	if conf.TwitterBearerToken == "" {
-		log.Warnw("Twitter credentials missing, won't do special responses for Twitter")
+		log.Warnw("Twitter credentials missing, using embed for Twitter")
+
+		cfg = conf
+
+		const tweetEndpointURLFormat = "https://cdn.syndication.twimg.com/tweet-result?id=%s&lang=en&features=tfw_timeline_list%%3A%%3Btfw_follower_count_sunset%%3Atrue%%3Btfw_tweet_edit_backend%%3Aon%%3Btfw_refsrc_session%%3Aon%%3Btfw_show_business_verified_badge%%3Aon%%3Btfw_duplicate_scribes_to_settings%%3Aon%%3Btfw_show_blue_verified_badge%%3Aon%%3Btfw_legacy_timeline_sunset%%3Atrue%%3Btfw_show_gov_verified_badge%%3Aon%%3Btfw_show_business_affiliate_badge%%3Aon%%3Btfw_tweet_edit_frontend%%3Aon"
+
+		*resolvers = append(
+			*resolvers,
+			NewEmbedResolver(
+				ctx, cfg, pool, tweetEndpointURLFormat, collageCache,
+			),
+		)
+
 		return
 	}
 	cfg = conf

--- a/internal/resolvers/twitter/initialize_test.go
+++ b/internal/resolvers/twitter/initialize_test.go
@@ -26,7 +26,7 @@ func TestInitialize(t *testing.T) {
 		collageCache := cache.NewPostgreSQLDependentCache(ctx, cfg, pool, cache.NewPrefixKeyProvider("test"))
 		c.Assert(customResolvers, qt.HasLen, 0)
 		Initialize(ctx, cfg, pool, &customResolvers, collageCache)
-		c.Assert(customResolvers, qt.HasLen, 0)
+		c.Assert(customResolvers, qt.HasLen, 1)
 	})
 
 	c.Run("Credentials", func(c *qt.C) {

--- a/internal/resolvers/twitter/resolver_test.go
+++ b/internal/resolvers/twitter/resolver_test.go
@@ -318,3 +318,221 @@ func TestResolver(t *testing.T) {
 		})
 	})
 }
+
+func TestEmbedResolver(t *testing.T) {
+	ctx := logger.OnContext(context.Background(), logger.NewTest())
+	c := qt.New(t)
+
+	datetime := time.Date(2019, time.November, 10, 23, 0, 0, 0, time.UTC).Unix()
+	fmt.Println(datetime)
+
+	cfg := config.APIConfig{
+		BaseURL:            "https://example.com/",
+		TwitterBearerToken: "",
+	}
+
+	pool, _ := pgxmock.NewPool()
+
+	ts := testEmbedServer()
+	defer ts.Close()
+
+	r := NewEmbedResolver(ctx,
+		cfg,
+		pool,
+		ts.URL+"/tweet-result?id=%s&lang=en&features=tfw_timeline_list%%3A%%3Btfw_follower_count_sunset%%3Atrue%%3Btfw_tweet_edit_backend%%3Aon%%3Btfw_refsrc_session%%3Aon%%3Btfw_show_business_verified_badge%%3Aon%%3Btfw_duplicate_scribes_to_settings%%3Aon%%3Btfw_show_blue_verified_badge%%3Aon%%3Btfw_legacy_timeline_sunset%%3Atrue%%3Btfw_show_gov_verified_badge%%3Aon%%3Btfw_show_business_affiliate_badge%%3Aon%%3Btfw_tweet_edit_frontend%%3Aon",
+		cache.NewPostgreSQLDependentCache(ctx, cfg, pool, cache.NewPrefixKeyProvider("test")),
+	)
+
+	c.Assert(r, qt.IsNotNil)
+
+	c.Run("Name", func(c *qt.C) {
+		c.Assert(r.Name(), qt.Equals, "twitter-embed")
+	})
+
+	c.Run("Check", func(c *qt.C) {
+		type checkTest struct {
+			label    string
+			input    *url.URL
+			expected bool
+		}
+
+		tests := []checkTest{
+			{
+				label:    "Matching domain, no WWW, user",
+				input:    utils.MustParseURL("https://twitter.com/pajlada"),
+				expected: false,
+			},
+			{
+				label:    "Matching domain, WWW, user",
+				input:    utils.MustParseURL("https://www.twitter.com/pajlada"),
+				expected: false,
+			},
+			{
+				label:    "Matching domain, tweet",
+				input:    utils.MustParseURL("https://twitter.com/pajlada/status/1507648130682077194"),
+				expected: true,
+			},
+			{
+				label:    "Matching domain, no WWW, http, user",
+				input:    utils.MustParseURL("http://twitter.com/pajlada"),
+				expected: false,
+			},
+			{
+				label:    "Matching domain, WWW, http, user",
+				input:    utils.MustParseURL("http://www.twitter.com/pajlada"),
+				expected: false,
+			},
+			{
+				label:    "Non-matching domain",
+				input:    utils.MustParseURL("https://google.com"),
+				expected: false,
+			},
+			{
+				label:    "Non-matching domain",
+				input:    utils.MustParseURL("https://nontwitter.com"),
+				expected: false,
+			},
+			{
+				label:    "Matching domain, no path",
+				input:    utils.MustParseURL("https://twitter.com/"),
+				expected: false,
+			},
+			{
+				label:    "Matching domain, ignored path",
+				input:    utils.MustParseURL("https://twitter.com/compose"),
+				expected: false,
+			},
+			{
+				label:    "Matching domain, ignored path",
+				input:    utils.MustParseURL("https://twitter.com/logout"),
+				expected: false,
+			},
+		}
+
+		for _, test := range tests {
+			c.Run(test.label, func(c *qt.C) {
+				_, output := r.Check(ctx, test.input)
+				c.Assert(output, qt.Equals, test.expected, qt.Commentf("URL was not handled as expected: %s", test.input))
+			})
+		}
+	})
+
+	c.Run("Run", func(c *qt.C) {
+		c.Run("Dont handle", func(c *qt.C) {
+			type runTest struct {
+				label          string
+				inputURL       *url.URL
+				inputEmoteHash string
+			}
+
+			tests := []runTest{
+				{
+					label:    "missing params",
+					inputURL: utils.MustParseURL("https://twitter.com"),
+				},
+			}
+
+			for _, test := range tests {
+				c.Run(test.label, func(c *qt.C) {
+					outputBytes, outputError := r.Run(ctx, test.inputURL, nil)
+					c.Assert(outputError, qt.Equals, resolver.ErrDontHandle)
+					c.Assert(outputBytes, qt.IsNil)
+					c.Assert(pool.ExpectationsWereMet(), qt.IsNil)
+				})
+			}
+		})
+
+		c.Run("Tweet", func(c *qt.C) {
+			type runTest struct {
+				label            string
+				inputURL         *url.URL
+				inputTweet       string
+				expectedResponse *cache.Response
+				expectedError    error
+				rowsReturned     int
+			}
+
+			tests := []runTest{
+				{
+					label:      "one-photo",
+					inputURL:   utils.MustParseURL("https://twitter.com/Forsen/status/1541102101782216706"),
+					inputTweet: "1541102101782216706",
+					expectedResponse: &cache.Response{
+						Payload:     []byte(`{"status":200,"thumbnail":"https://pbs.twimg.com/media/FWMYHYSWYAAyWMp.jpg","tooltip":"%3Cdiv%20style=%22text-align:%20left%3B%22%3E%0A%3Cb%3ESebastian%20Fors%20%28@Forsen%29%3C%2Fb%3E%0A%3Cspan%20style=%22white-space:%20pre-wrap%3B%20word-wrap:%20break-word%3B%22%3E%0ASince%20I%20switched%20to%20rifle%20and%204:3%20its%20been%20pretty%20easy.%20People%20calling%20me%20bad%20when%20they%20were%20already%20playing%20on%20the%20easiest%20difficulty%F0%9F%A4%A3%F0%9F%A4%A3%F0%9F%A4%A3%F0%9F%98%8E%20https:%2F%2Ft.co%2FjfbLdsPTwZ%0A%3C%2Fspan%3E%0A%3Cspan%20style=%22color:%20%23808892%3B%22%3E4%2C966%20likes\u0026nbsp%3B%E2%80%A2\u0026nbsp%3B242%20replies\u0026nbsp%3B%E2%80%A2\u0026nbsp%3B26%20Jun%202022%20%E2%80%A2%2016:52%20UTC%3C%2Fspan%3E%0A%3C%2Fdiv%3E%0A"}`),
+						StatusCode:  http.StatusOK,
+						ContentType: "application/json",
+					},
+					expectedError: nil,
+				},
+				{
+					label:      "no-media",
+					inputURL:   utils.MustParseURL("https://twitter.com/Forsen/status/1662863815787126787"),
+					inputTweet: "1662863815787126787",
+					expectedResponse: &cache.Response{
+						Payload:     []byte(`{"status":200,"tooltip":"%3Cdiv%20style=%22text-align:%20left%3B%22%3E%0A%3Cb%3ESebastian%20Fors%20%28@Forsen%29%3C%2Fb%3E%0A%3Cspan%20style=%22white-space:%20pre-wrap%3B%20word-wrap:%20break-word%3B%22%3E%0APlaying%20some%20more%20warlander%20today%20on%20stream%21%20Free%20to%20play%20and%20join%21%20Get%20it%20here%20https:%2F%2Ft.co%2Frh3IBOvymE%20%21%20@PlayWarlander%20%23Warlander%0A%3C%2Fspan%3E%0A%3Cspan%20style=%22color:%20%23808892%3B%22%3E437%20likes\u0026nbsp%3B%E2%80%A2\u0026nbsp%3B87%20replies\u0026nbsp%3B%E2%80%A2\u0026nbsp%3B28%20May%202023%20%E2%80%A2%2016:50%20UTC%3C%2Fspan%3E%0A%3C%2Fdiv%3E%0A"}`),
+						StatusCode:  http.StatusOK,
+						ContentType: "application/json",
+					},
+					expectedError: nil,
+				},
+				{
+					label:      "no ID",
+					inputURL:   utils.MustParseURL("https://twitter.com/Forsen/status/1662863815787126788"),
+					inputTweet: "1662863815787126788",
+					expectedResponse: &cache.Response{
+						Payload:     []byte(`{"status":404,"message":"Twitter tweet not found: 1662863815787126788"}`),
+						StatusCode:  http.StatusOK,
+						ContentType: "application/json",
+					},
+					expectedError: nil,
+				},
+				{
+					label:      "404",
+					inputURL:   utils.MustParseURL("https://twitter.com/pajlada/status/404"),
+					inputTweet: "404",
+					expectedResponse: &cache.Response{
+						Payload:     []byte(`{"status":404,"message":"Twitter tweet not found: 404"}`),
+						StatusCode:  http.StatusOK,
+						ContentType: "application/json",
+					},
+					expectedError: nil,
+				},
+				{
+					label:      "500",
+					inputURL:   utils.MustParseURL("https://twitter.com/pajlada/status/500"),
+					inputTweet: "500",
+					expectedResponse: &cache.Response{
+						Payload:     []byte(`{"status":500,"message":"Twitter tweet API error: unhandled status code: 500"}`),
+						StatusCode:  http.StatusOK,
+						ContentType: "application/json",
+					},
+					expectedError: nil,
+				},
+				{
+					label:      "bad JSON",
+					inputURL:   utils.MustParseURL("https://twitter.com/pajlada/status/bad"),
+					inputTweet: "bad",
+					expectedResponse: &cache.Response{
+						Payload:     []byte(`{"status":500,"message":"Twitter tweet API error: unable to unmarshal response"}`),
+						StatusCode:  http.StatusOK,
+						ContentType: "application/json",
+					},
+					expectedError: nil,
+				},
+			}
+
+			for _, test := range tests {
+				c.Run(test.label, func(c *qt.C) {
+					pool.ExpectQuery("SELECT").WillReturnError(pgx.ErrNoRows)
+					pool.ExpectExec("INSERT INTO cache").
+						WithArgs("twitter-embed:tweet:"+test.inputTweet, test.expectedResponse.Payload, test.expectedResponse.StatusCode, test.expectedResponse.ContentType, pgxmock.AnyArg()).
+						WillReturnResult(pgxmock.NewResult("INSERT", 1))
+					outputBytes, outputError := r.Run(ctx, test.inputURL, nil)
+					c.Assert(outputError, qt.Equals, test.expectedError)
+					c.Assert(outputBytes, qt.DeepEquals, test.expectedResponse)
+					c.Assert(pool.ExpectationsWereMet(), qt.IsNil)
+				})
+			}
+		})
+	})
+}


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

If no Twitter API key is configured, the twitter resolver uses the embed endpoint (used by [vercel/react-tweet](https://github.com/vercel/react-tweet) as well). The only downside is that retweets aren't displayed.
