### PR TITLE
Use logger for skipping url message instead of fmt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Dev: Document the `log-level` setting. (#490)
 - Dev: Add some `pkg/utils/url.go` tests. (#525)
 - Dev: Make `IsSubdomainOf` variadic, making it easier for users of it to support multiple top level domains. (#526)
+- Dev: Use logger for skipping url message instead of fmt. (#554)
 
 ## 2.0.2
 

--- a/internal/resolvers/default/link_loader.go
+++ b/internal/resolvers/default/link_loader.go
@@ -103,7 +103,7 @@ func (l *LinkLoader) Load(ctx context.Context, urlString string, r *http.Request
 	}
 
 	if resp.StatusCode < http.StatusOK || resp.StatusCode > http.StatusMultipleChoices {
-		log.Infow(fmt.Sprintf("Skipping url %s because status code is %d", resp.Request.URL, resp.StatusCode))
+		log.Infow("Skipping url because of status code", "url", resp.Request.URL, "status", resp.StatusCode)
 		return staticresponse.SNoLinkInfoFound.Return()
 	}
 

--- a/internal/resolvers/default/link_loader.go
+++ b/internal/resolvers/default/link_loader.go
@@ -103,7 +103,7 @@ func (l *LinkLoader) Load(ctx context.Context, urlString string, r *http.Request
 	}
 
 	if resp.StatusCode < http.StatusOK || resp.StatusCode > http.StatusMultipleChoices {
-		fmt.Println("Skipping url", resp.Request.URL, "because status code is", resp.StatusCode)
+		log.Infow(fmt.Sprintf("Skipping url %s because status code is %d", resp.Request.URL, resp.StatusCode))
 		return staticresponse.SNoLinkInfoFound.Return()
 	}
 

--- a/internal/resolvers/default/thumbnail_loader.go
+++ b/internal/resolvers/default/thumbnail_loader.go
@@ -64,7 +64,7 @@ func (l *ThumbnailLoader) Load(ctx context.Context, urlString string, r *http.Re
 	}
 
 	if resp.StatusCode < http.StatusOK || resp.StatusCode > http.StatusMultipleChoices {
-		fmt.Println("Skipping url", resp.Request.URL, "because status code is", resp.StatusCode)
+		log.Infow("Skipping url %s because status code is $d", resp.Request.URL, resp.StatusCode)
 		return staticresponse.SNoThumbnailFound.Return()
 	}
 

--- a/internal/resolvers/default/thumbnail_loader.go
+++ b/internal/resolvers/default/thumbnail_loader.go
@@ -64,7 +64,7 @@ func (l *ThumbnailLoader) Load(ctx context.Context, urlString string, r *http.Re
 	}
 
 	if resp.StatusCode < http.StatusOK || resp.StatusCode > http.StatusMultipleChoices {
-		log.Infow("Skipping url %s because status code is $d", resp.Request.URL, resp.StatusCode)
+		log.Infow("Skipping url %s because status code is %d", resp.Request.URL, resp.StatusCode)
 		return staticresponse.SNoThumbnailFound.Return()
 	}
 

--- a/internal/resolvers/default/thumbnail_loader.go
+++ b/internal/resolvers/default/thumbnail_loader.go
@@ -64,7 +64,7 @@ func (l *ThumbnailLoader) Load(ctx context.Context, urlString string, r *http.Re
 	}
 
 	if resp.StatusCode < http.StatusOK || resp.StatusCode > http.StatusMultipleChoices {
-		log.Infow("Skipping url %s because status code is %d", resp.Request.URL, resp.StatusCode)
+		log.Infow("Skipping url because of status code", "url", resp.Request.URL, "status", resp.StatusCode)
 		return staticresponse.SNoThumbnailFound.Return()
 	}
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

I noticed the log being hard to read, since some messages were not using the standard logger.
