### PR TITLE
Don't initialize youtube resolver if youtube-api-key is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Dev: Add some `pkg/utils/url.go` tests. (#525)
 - Dev: Make `IsSubdomainOf` variadic, making it easier for users of it to support multiple top level domains. (#526)
 - Dev: Use logger for skipping url message instead of fmt. (#554)
+- Dev: Don't initialize youtube resolver if youtube-api-key is empty. (#556)
 
 ## 2.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Dev: Add some `pkg/utils/url.go` tests. (#525)
 - Dev: Make `IsSubdomainOf` variadic, making it easier for users of it to support multiple top level domains. (#526)
 - Dev: Use logger for skipping url message instead of fmt. (#554)
-- Dev: Don't initialize youtube resolver if youtube-api-key is empty. (#556)
+- Dev: Improve YoutTube resolver initialization logging. (#556)
 
 ## 2.0.2
 

--- a/internal/resolvers/youtube/initialize.go
+++ b/internal/resolvers/youtube/initialize.go
@@ -55,9 +55,15 @@ func NewYouTubeVideoResolvers(ctx context.Context, cfg config.APIConfig, pool db
 func Initialize(ctx context.Context, cfg config.APIConfig, pool db.Pool, resolvers *[]resolver.Resolver) {
 	log := logger.FromContext(ctx)
 
+	if cfg.YoutubeApiKey == "" {
+		log.Warnw("[Config] youtube-api-key missing, won't do special responses for YouTube")
+		return
+
+	}
+
 	youtubeClient, err := youtubeAPI.NewService(ctx, option.WithAPIKey(cfg.YoutubeApiKey))
 	if err != nil {
-		log.Warnw("[Config] youtube-api-key missing or otherwise misconfigured, won't do special responses for YouTube",
+		log.Warnw("[Config] Failed to create youtube client, won't do special responses for YouTube",
 			"error", err,
 		)
 		return

--- a/internal/resolvers/youtube/initialize_test.go
+++ b/internal/resolvers/youtube/initialize_test.go
@@ -2,6 +2,7 @@ package youtube
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/Chatterino/api/internal/logger"
@@ -16,6 +17,11 @@ func TestInitialize(t *testing.T) {
 	c := qt.New(t)
 
 	pool, err := pgxmock.NewPool()
+	c.Assert(err, qt.IsNil)
+
+	// google.golang.org/api/youtube/v3 automatically
+	// uses this environment variable to initialize clients
+	err = os.Unsetenv("GOOGLE_APPLICATION_CREDENTIALS")
 	c.Assert(err, qt.IsNil)
 
 	c.Run("No YouTube API key", func(c *qt.C) {

--- a/internal/resolvers/youtube/initialize_test.go
+++ b/internal/resolvers/youtube/initialize_test.go
@@ -2,7 +2,6 @@ package youtube
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/Chatterino/api/internal/logger"
@@ -21,8 +20,7 @@ func TestInitialize(t *testing.T) {
 
 	// google.golang.org/api/youtube/v3 automatically
 	// uses this environment variable to initialize clients
-	err = os.Unsetenv("GOOGLE_APPLICATION_CREDENTIALS")
-	c.Assert(err, qt.IsNil)
+	c.Unsetenv("GOOGLE_APPLICATION_CREDENTIALS")
 
 	c.Run("No YouTube API key", func(c *qt.C) {
 		cfg := config.APIConfig{


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Don't initialize youtube resolver if api key is empty. As far as I can tell from reading the source, the package we are using does not care about the api key being empty and does not return an error.

~~The test in `intialize_test.go` fails for me locally, but it passes in CI.~~
~~That might be worth an investigation?~~
Turns out `google.golang.org/api/youtube/v3` automatically pulls in creentials from `GOOGLE_APPLICATION_CREDENTIALS`
