### PR TITLE
Truncate playlist descriptions to 400 characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Minor: Add playlist support to YouTube resolver. (#597)
+- Minor: Add playlist support to YouTube resolver. (#597, #601)
 
 ## 2.0.3
 

--- a/internal/resolvers/youtube/playlist_loader.go
+++ b/internal/resolvers/youtube/playlist_loader.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Chatterino/api/pkg/cache"
 	"github.com/Chatterino/api/pkg/humanize"
 	"github.com/Chatterino/api/pkg/resolver"
+	"github.com/Chatterino/api/pkg/utils"
 	youtubeAPI "google.golang.org/api/youtube/v3"
 )
 
@@ -40,6 +41,8 @@ func getThumbnailUrl(thumbnailDetails *youtubeAPI.ThumbnailDetails) string {
 }
 
 func (r *YouTubePlaylistLoader) Load(ctx context.Context, playlistCacheKey string, req *http.Request) ([]byte, *int, *string, time.Duration, error) {
+	const MaxDescriptionLength = 400
+
 	log := logger.FromContext(ctx)
 	log.Debugw("[YouTube] GET playlist",
 		"cacheKey", playlistCacheKey,
@@ -74,7 +77,7 @@ func (r *YouTubePlaylistLoader) Load(ctx context.Context, playlistCacheKey strin
 
 	data := youtubePlaylistTooltipData{
 		Title:       youtubePlaylist.Snippet.Title,
-		Description: youtubePlaylist.Snippet.Description,
+		Description: utils.TruncateString(youtubePlaylist.Snippet.Description, MaxDescriptionLength),
 		Channel:     youtubePlaylist.Snippet.ChannelTitle,
 		VideoCount:  humanize.NumberInt64(youtubePlaylist.ContentDetails.ItemCount),
 		PublishedAt: humanize.CreationDateRFC3339(youtubePlaylist.Snippet.PublishedAt),


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Without this, playlist tooltips can go a little bit crazy

![image](https://github.com/Chatterino/api/assets/962989/61414729-db78-474f-8f31-6069e06bc44e)


<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
