### PR TITLE
Exclude /results from channel resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Minor: Add playlist support to YouTube resolver. (#597, #601)
+- Fix: Do not resolve /results using YouTube channel resolver (#616)
 
 ## 2.0.3
 

--- a/internal/resolvers/youtube/channel_resolver.go
+++ b/internal/resolvers/youtube/channel_resolver.go
@@ -26,6 +26,10 @@ func (r *YouTubeChannelResolver) Check(ctx context.Context, url *url.URL) (conte
 		return ctx, false
 	}
 
+	if url.Path == "/results" {
+		return ctx, false
+	}
+
 	q := url.Query()
 	// TODO(go1.18): Replace with q.Has("v") once we've transitioned to at least go 1.17 as least supported version
 	if q.Has("v") {

--- a/internal/resolvers/youtube/channel_resolver_test.go
+++ b/internal/resolvers/youtube/channel_resolver_test.go
@@ -141,6 +141,11 @@ func TestChannelResolver(t *testing.T) {
 				expected: false,
 			},
 			{
+				label:    "Correct domain, results path",
+				input:    utils.MustParseURL("https://youtube.com/results?search_query=test"),
+				expected: false,
+			},
+			{
 				label:    "Incorrect domain",
 				input:    utils.MustParseURL("https://example.com/watch?v=foobar"),
 				expected: false,


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable


https://www.youtube.com/results?search_query=test currently resolves to https://www.youtube.com/@AdministrativeResults.

I would have liked to fix this in the regex, but didn't manage to. Open to suggestions.