### PR TITLE
fix(twitch): support slash at the end of user urls

### DIFF
--- a/internal/resolvers/twitch/data_test.go
+++ b/internal/resolvers/twitch/data_test.go
@@ -44,6 +44,7 @@ var validUsers = []string{
 	"https://twitch.tv/pajlada",
 	"https://www.twitch.tv/pajlada",
 	"https://twitch.tv/matthewde",
+	"https://twitch.tv/forsen/",
 }
 
 var invalidUsers = []string{

--- a/internal/resolvers/twitch/user_resolver.go
+++ b/internal/resolvers/twitch/user_resolver.go
@@ -14,7 +14,7 @@ import (
 	"github.com/Chatterino/api/pkg/utils"
 )
 
-var userRegex = regexp.MustCompile(`^\/([a-zA-Z0-9_]+)$`)
+var userRegex = regexp.MustCompile(`^\/([a-zA-Z0-9_]+)\/?$`)
 var ignoredUsers = []string{
 	"inventory",
 	"popout",


### PR DESCRIPTION
this means we support `twitch.tv/forsen/` in addition to just `twitch.tv/forsen`

Pull request checklist:

- [ ] `CHANGELOG.md` was updated, if applicable

# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
